### PR TITLE
Traktor api

### DIFF
--- a/src/traktor_api/data_provider.rs
+++ b/src/traktor_api/data_provider.rs
@@ -86,21 +86,17 @@ impl TraktorDataProvider {
     }
 
     fn get_deck_score(&self, deck: &DeckState, channel: &ChannelState, mixer: &MixerState) -> f64 {
-        if !deck.content.is_loaded || deck.play_state.speed == 0.0 {
+        if !deck.content.is_loaded || deck.play_state.speed == 0.0 || channel.volume == 0.0 {
             return 0.0;
         }
 
-        let mut score = channel.volume;
-
         if channel.x_fader_left && mixer.x_fader > 0.5 {
-            score *= (mixer.x_fader - 0.5) * 2.0;
+            (mixer.x_fader - 0.5) * 2.0
+        } else if channel.x_fader_right && mixer.x_fader < 0.5 {
+            mixer.x_fader * 2.0
+        } else {
+            1.0
         }
-
-        if channel.x_fader_right && mixer.x_fader < 0.5 {
-            score *= mixer.x_fader * 2.0;
-        }
-
-        score
     }
 
     fn update_song_info(&mut self) {

--- a/src/traktor_api/data_provider.rs
+++ b/src/traktor_api/data_provider.rs
@@ -91,7 +91,7 @@ impl TraktorDataProvider {
         }
 
         if channel.x_fader_left && mixer.x_fader > 0.5 {
-            (mixer.x_fader - 0.5) * 2.0
+            (1.0 - mixer.x_fader) * 2.0
         } else if channel.x_fader_right && mixer.x_fader < 0.5 {
             mixer.x_fader * 2.0
         } else {

--- a/src/traktor_api/model.rs
+++ b/src/traktor_api/model.rs
@@ -181,6 +181,7 @@ pub struct DeckState {
 pub struct DeckContentState {
     pub is_loaded: bool,
 
+    pub number: u32,
     pub title: String,
     pub artist: String,
     pub album: String,

--- a/traktor-api/Api/ApiDeck.qml
+++ b/traktor-api/Api/ApiDeck.qml
@@ -20,6 +20,7 @@ Item {
     AppProperty { id: propIsLoaded; path: `app.traktor.decks.${index + 1}.is_loaded`; onValueChanged: updateContent(false) }
     AppProperty { id: propIsLoadedSignal; path: `app.traktor.decks.${index + 1}.is_loaded_signal`; onValueChanged: updateContent(false) }
 
+    AppProperty { id: propNumber; path: `app.traktor.decks.${index + 1}.content.number`; onValueChanged: updateContentProp() }
     AppProperty { id: propTitle; path: `app.traktor.decks.${index + 1}.content.title`; onValueChanged: updateContentProp() }
     AppProperty { id: propArtist; path: `app.traktor.decks.${index + 1}.content.artist`; onValueChanged: updateContentProp() }
     AppProperty { id: propAlbum; path: `app.traktor.decks.${index + 1}.content.album`; onValueChanged: updateContentProp() }
@@ -82,6 +83,7 @@ Item {
         ApiClient.sendUpdate(contentApiId, {
             isLoaded,
 
+            number: isLoaded ? propNumber.value : 0,
             title: isLoaded ? propTitle.value : "",
             artist: isLoaded ? propArtist.value : "",
             album: isLoaded ? propAlbum.value : "",


### PR DESCRIPTION
This pull request introduces enhancements to the Traktor API by refining deck scoring logic, adding a new `number` field to deck content, and updating the QML API to support this new field. These changes improve the accuracy of deck scoring and extend the API's functionality for better integration.

### Enhancements to deck scoring logic:
* In `src/traktor_api/data_provider.rs`, the `get_deck_score` method was updated to include a check for `channel.volume == 0.0` when determining if a deck should score zero. Additionally, the logic for calculating the score based on the crossfader position was simplified to return values directly instead of mutating a `score` variable.

### Addition of `number` field to deck content:
* In `src/traktor_api/model.rs`, a new `number` field was added to the `DeckContentState` struct to represent the deck's unique identifier.

### Updates to QML API:
* In `traktor-api/Api/ApiDeck.qml`, a new property `propNumber` was added to expose the `number` field from the deck content. This property triggers updates when its value changes.
* In the same file, the `number` field was included in the `ApiClient.sendUpdate` method to ensure it is sent as part of the deck's content updates.