### PR TITLE
Restructure UI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1917,9 +1917,9 @@ dependencies = [
 
 [[package]]
 name = "iced_aw"
-version = "0.13.1"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e676b8d322a419c7eef29cac1aa78e8afda6a9d2d4597483d42de3e90378fe2"
+checksum = "59b7f923642b024c415150b70ef84ee5c11626e3b0af73b954d817d573bcd0a4"
 dependencies = [
  "cfg-if",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ authors = ["Klassenserver7b <klassenserver7bwin10@gmail.com>", "Konsl <82901383+
 id3 = "1.16"
 url = "2.5"
 percent-encoding = "2.3"
-iced = { version = "0.14.0", features = ["linux-theme-detection", "image", "debug", "wayland", "svg", "lazy", "canvas", "tokio", "advanced"] }
+iced = { version = "0.14.0", features = ["linux-theme-detection", "image", "wayland", "svg", "lazy", "canvas", "tokio", "advanced", "debug"] }
 iced_aw = { version = "0.13.1", features = ["default"] }
 #iced_anim = { version = "0.3.1", features = ["derive", "widgets"] }
 rfd = "0.17"
@@ -35,5 +35,5 @@ futures-util = "0.3"
 
 [features]
 default = ["mdns"]
-debug = ["iced/hot"]
+hot = ["iced/hot"]
 mdns = ["dep:libmdns"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,13 +10,13 @@ authors = ["Klassenserver7b <klassenserver7bwin10@gmail.com>", "Konsl <82901383+
 id3 = "1.16"
 url = "2.5"
 percent-encoding = "2.3"
-iced = { version = "0.14.0", features = ["linux-theme-detection", "image", "wayland", "svg", "lazy", "canvas", "tokio", "advanced", "debug"] }
-iced_aw = { version = "0.13.1", features = ["default"] }
+iced = { version = "0.14.0", features = ["linux-theme-detection", "image", "wayland", "svg", "lazy", "canvas", "tokio", "advanced"] }
+iced_aw = { version = "0.14.1", features = ["default"] }
 #iced_anim = { version = "0.3.1", features = ["derive", "widgets"] }
 rfd = "0.17"
 dirs = "6.0"
 warp = { version = "0.4", features = ["websocket", "server"] }
-tokio = "1.51"
+tokio = { version = "1.51" }
 pin-project-lite = "0.2"
 serde = { version = "1.0", features = ["derive"] }
 uuid = { version = "1.22", features = ["v4"] }
@@ -27,6 +27,7 @@ image = "0.25"
 
 [dev-dependencies]
 warp = { version = "0.4", features = ["websocket", "server", "test"] }
+tokio = { version = "1.51", features = ["macros"] }
 tokio-tungstenite = "0.29"
 serde_json = "1.0.149"
 reqwest = { version = "0.13", features = ["json"] }
@@ -35,5 +36,6 @@ futures-util = "0.3"
 
 [features]
 default = ["mdns"]
+debug = ["iced/debug"]
 hot = ["iced/hot"]
 mdns = ["dep:libmdns"]

--- a/src/dataloading/dataprovider/song_data_provider.rs
+++ b/src/dataloading/dataprovider/song_data_provider.rs
@@ -246,4 +246,32 @@ impl SongDataProvider {
             _ => None,
         }
     }
+
+    pub fn get_play_state(&self, playlist_index: usize) -> (bool, bool, bool, bool) {
+        let mut is_current = false;
+        let mut is_next = false;
+        let mut is_traktor = false;
+        let is_played = self
+            .playlist_played
+            .get(playlist_index)
+            .copied()
+            .unwrap_or(false);
+
+        if let SongDataSource::Playlist(i) = self.current {
+            is_current = playlist_index == i;
+            is_next = playlist_index == (i + 1);
+        }
+
+        if let Some(SongDataSource::Playlist(i)) = self.next {
+            is_next = playlist_index == i;
+        }
+
+        if matches!(self.current, SongDataSource::Traktor)
+            && let Some(index) = self.get_current_traktor_index()
+        {
+            is_traktor = playlist_index == index;
+        }
+
+        (is_current, is_next, is_traktor, is_played)
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -410,6 +410,7 @@ impl DanceInterpreter {
 
             Message::TraktorEnableServer(enabled) => {
                 self.data_provider.traktor_provider.is_enabled = enabled;
+                self.config_window.power_button_cache.clear();
                 ().into()
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,6 +27,7 @@ use iced_aw::ICED_AW_FONT_BYTES;
 use rfd::FileDialog;
 use std::env::var;
 use std::path::PathBuf;
+use std::time::Instant;
 
 fn main() -> iced::Result {
     iced::daemon(
@@ -77,6 +78,8 @@ pub enum Message {
     ScrollBy(f32),
     SnapTo(RelativeOffset),
     AddBlankSong(RelativeOffset),
+    ToggleRightSidebar,
+    Animate,
 
     FileDropped(PathBuf),
     SongChanged(SongChange),
@@ -382,6 +385,15 @@ impl DanceInterpreter {
 
             Message::SnapTo(offset) => snap_to(PLAYLIST_SCROLLABLE_ID.clone(), offset),
 
+            Message::ToggleRightSidebar => {
+                self.config_window
+                    .sidebar_slidein
+                    .go_mut(!self.config_window.sidebar_slidein.value(), Instant::now());
+                ().into()
+            }
+
+            Message::Animate => Task::none(),
+
             Message::TraktorMessage(msg) => {
                 self.data_provider.process_traktor_message(*msg);
                 self.run_traktor_sync_action();
@@ -545,6 +557,15 @@ impl DanceInterpreter {
                 }
             }),
             system::theme_changes().map(Message::ThemeChanged),
+            if self
+                .config_window
+                .sidebar_slidein
+                .is_animating(Instant::now())
+            {
+                window::frames().map(|_| Message::Animate)
+            } else {
+                Subscription::none()
+            },
         ];
 
         if let Some(addr) = self.data_provider.traktor_provider.get_socket_addr() {

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,7 @@ use crate::dataloading::songinfo::SongInfo;
 use crate::traktor_api::{
     ServerMessage, StateUpdate, TraktorNextMode, TraktorSyncAction, TraktorSyncMode,
 };
-use crate::ui::config_window::{ConfigWindow, PLAYLIST_SCROLLABLE_ID};
+use crate::ui::config_window::{ConfigWindow, PLAYLIST_SCROLLABLE_ID, SidebarMessage};
 use crate::ui::song_window::SongWindow;
 use iced::keyboard::key::Named;
 use iced::keyboard::{Key, Modifiers};
@@ -78,7 +78,7 @@ pub enum Message {
     ScrollBy(f32),
     SnapTo(RelativeOffset),
     AddBlankSong(RelativeOffset),
-    ToggleRightSidebar,
+    Sidebar(SidebarMessage),
     Animate,
 
     FileDropped(PathBuf),
@@ -385,12 +385,19 @@ impl DanceInterpreter {
 
             Message::SnapTo(offset) => snap_to(PLAYLIST_SCROLLABLE_ID.clone(), offset),
 
-            Message::ToggleRightSidebar => {
-                self.config_window
-                    .sidebar_state
-                    .go_mut(!self.config_window.sidebar_state.value(), Instant::now());
-                ().into()
-            }
+            Message::Sidebar(msg) => match msg {
+                SidebarMessage::Toggle => {
+                    self.config_window
+                        .sidebar_state
+                        .go_mut(!self.config_window.sidebar_state.value(), Instant::now());
+                    ().into()
+                }
+                SidebarMessage::UpdateAddressPresets => {
+                    self.config_window
+                        .update_network_interface_selection(&self.data_provider);
+                    ().into()
+                }
+            },
 
             Message::Animate => Task::none(),
 
@@ -553,6 +560,9 @@ impl DanceInterpreter {
                         Some(Message::AddBlankSong(RelativeOffset::END))
                     }
                     (Key::Character("r"), Modifiers::CTRL) => Some(Message::ReloadStatics),
+                    (Key::Character("c"), Modifiers::ALT) => {
+                        Some(Message::Sidebar(SidebarMessage::Toggle))
+                    }
                     _ => None,
                 }
             }),

--- a/src/main.rs
+++ b/src/main.rs
@@ -91,9 +91,9 @@ pub enum Message {
     EnableAutoscroll(bool),
 
     TraktorMessage(Box<ServerMessage>),
-    TraktorSetSyncMode(Option<TraktorSyncMode>),
-    TraktorSetNextMode(Option<TraktorNextMode>),
-    TraktorSetNextModeFallback(Option<TraktorNextMode>),
+    TraktorSetSyncMode(TraktorSyncMode),
+    TraktorSetNextMode(TraktorNextMode),
+    TraktorSetNextModeFallback(TraktorNextMode),
     TraktorEnableServer(bool),
     TraktorChangeAddress(String),
     TraktorSubmitAddress,
@@ -387,8 +387,8 @@ impl DanceInterpreter {
 
             Message::ToggleRightSidebar => {
                 self.config_window
-                    .sidebar_slidein
-                    .go_mut(!self.config_window.sidebar_slidein.value(), Instant::now());
+                    .sidebar_state
+                    .go_mut(!self.config_window.sidebar_state.value(), Instant::now());
                 ().into()
             }
 
@@ -559,7 +559,7 @@ impl DanceInterpreter {
             system::theme_changes().map(Message::ThemeChanged),
             if self
                 .config_window
-                .sidebar_slidein
+                .sidebar_state
                 .is_animating(Instant::now())
             {
                 window::frames().map(|_| Message::Animate)

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,9 +14,9 @@ use crate::dataloading::songinfo::SongInfo;
 use crate::traktor_api::{
     ServerMessage, StateUpdate, TraktorNextMode, TraktorSyncAction, TraktorSyncMode,
 };
-use crate::ui::config_window::{
-    BottomBarMessage, ConfigWindow, PLAYLIST_SCROLLABLE_ID, SidebarMessage,
-};
+use crate::ui::config_window::bottombar::BottomBarMessage;
+use crate::ui::config_window::sidebar::SidebarMessage;
+use crate::ui::config_window::{ConfigWindow, PLAYLIST_SCROLLABLE_ID};
 use crate::ui::song_window::SongWindow;
 use iced::keyboard::key::Named;
 use iced::keyboard::{Key, Modifiers};
@@ -391,12 +391,14 @@ impl DanceInterpreter {
             Message::Sidebar(msg) => match msg {
                 SidebarMessage::Toggle => {
                     self.config_window
-                        .sidebar_state
-                        .go_mut(!self.config_window.sidebar_state.value(), Instant::now());
+                        .sidebar
+                        .state
+                        .go_mut(!self.config_window.sidebar.state.value(), Instant::now());
                     ().into()
                 }
                 SidebarMessage::UpdateAddressPresets => {
                     self.config_window
+                        .sidebar
                         .update_network_interface_selection(&self.data_provider);
                     ().into()
                 }
@@ -405,8 +407,9 @@ impl DanceInterpreter {
             Message::Bottombar(msg) => match msg {
                 BottomBarMessage::Toggle => {
                     self.config_window
-                        .bottombar_state
-                        .go_mut(!self.config_window.bottombar_state.value(), Instant::now());
+                        .bottombar
+                        .state
+                        .go_mut(!self.config_window.bottombar.state.value(), Instant::now());
                     ().into()
                 }
             },
@@ -422,7 +425,7 @@ impl DanceInterpreter {
 
             Message::TraktorEnableServer(enabled) => {
                 self.data_provider.traktor_provider.is_enabled = enabled;
-                self.config_window.power_button_cache.clear();
+                self.config_window.sidebar.power_button_cache.clear();
                 ().into()
             }
 
@@ -582,11 +585,13 @@ impl DanceInterpreter {
             system::theme_changes().map(Message::ThemeChanged),
             if self
                 .config_window
-                .sidebar_state
+                .sidebar
+                .state
                 .is_animating(Instant::now())
                 || self
                     .config_window
-                    .bottombar_state
+                    .bottombar
+                    .state
                     .is_animating(Instant::now())
             {
                 window::frames().map(|_| Message::Animate)

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,7 +14,9 @@ use crate::dataloading::songinfo::SongInfo;
 use crate::traktor_api::{
     ServerMessage, StateUpdate, TraktorNextMode, TraktorSyncAction, TraktorSyncMode,
 };
-use crate::ui::config_window::{ConfigWindow, PLAYLIST_SCROLLABLE_ID, SidebarMessage};
+use crate::ui::config_window::{
+    BottomBarMessage, ConfigWindow, PLAYLIST_SCROLLABLE_ID, SidebarMessage,
+};
 use crate::ui::song_window::SongWindow;
 use iced::keyboard::key::Named;
 use iced::keyboard::{Key, Modifiers};
@@ -79,6 +81,7 @@ pub enum Message {
     SnapTo(RelativeOffset),
     AddBlankSong(RelativeOffset),
     Sidebar(SidebarMessage),
+    Bottombar(BottomBarMessage),
     Animate,
 
     FileDropped(PathBuf),
@@ -399,6 +402,15 @@ impl DanceInterpreter {
                 }
             },
 
+            Message::Bottombar(msg) => match msg {
+                BottomBarMessage::Toggle => {
+                    self.config_window
+                        .bottombar_state
+                        .go_mut(!self.config_window.bottombar_state.value(), Instant::now());
+                    ().into()
+                }
+            },
+
             Message::Animate => Task::none(),
 
             Message::TraktorMessage(msg) => {
@@ -572,6 +584,10 @@ impl DanceInterpreter {
                 .config_window
                 .sidebar_state
                 .is_animating(Instant::now())
+                || self
+                    .config_window
+                    .bottombar_state
+                    .is_animating(Instant::now())
             {
                 window::frames().map(|_| Message::Animate)
             } else {

--- a/src/main.rs
+++ b/src/main.rs
@@ -426,6 +426,7 @@ impl DanceInterpreter {
             Message::TraktorEnableServer(enabled) => {
                 self.data_provider.traktor_provider.is_enabled = enabled;
                 self.config_window.sidebar.power_button_cache.clear();
+                self.config_window.sidebar.restart_button_cache.clear();
                 ().into()
             }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -581,6 +581,9 @@ impl DanceInterpreter {
                     (Key::Character("c"), Modifiers::ALT) => {
                         Some(Message::Sidebar(SidebarMessage::Toggle))
                     }
+                    (Key::Character("b"), Modifiers::ALT) => {
+                        Some(Message::Bottombar(BottomBarMessage::Toggle))
+                    }
                     _ => None,
                 }
             }),

--- a/src/main.rs
+++ b/src/main.rs
@@ -456,6 +456,7 @@ impl DanceInterpreter {
 
             Message::TraktorReconnect => {
                 self.data_provider.traktor_provider.reconnect();
+                self.config_window.sidebar.restart_button_cache.clear();
                 ().into()
             }
 

--- a/src/traktor_api/data_provider.rs
+++ b/src/traktor_api/data_provider.rs
@@ -6,6 +6,7 @@ use crate::traktor_api::{
 use iced::futures::channel::mpsc::UnboundedSender;
 use iced::widget::image;
 use std::collections::HashMap;
+use std::fmt::Display;
 use std::mem;
 use std::net::SocketAddr;
 
@@ -13,6 +14,7 @@ pub const TRAKTOR_SERVER_DEFAULT_ADDR: &str = "127.0.0.1:8080";
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum TraktorNextMode {
+    None,
     DeckByPosition,
     DeckByNumber,
     PlaylistByNumber,
@@ -21,6 +23,7 @@ pub enum TraktorNextMode {
 
 #[derive(Debug, Copy, Clone, Eq, PartialEq)]
 pub enum TraktorSyncMode {
+    None,
     Relative,
     AbsoluteByNumber,
     AbsoluteByName,
@@ -32,14 +35,32 @@ pub enum TraktorSyncAction {
     PlaylistAbsolute(usize),
 }
 
+impl Display for TraktorNextMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl Display for TraktorSyncMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
+impl Display for TraktorSyncAction {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{:?}", self)
+    }
+}
+
 pub struct TraktorDataProvider {
     pub is_enabled: bool,
     pub address: String,
     pub submitted_address: String,
 
-    pub next_mode: Option<TraktorNextMode>,
-    pub next_mode_fallback: Option<TraktorNextMode>,
-    pub sync_mode: Option<TraktorSyncMode>,
+    pub next_mode: TraktorNextMode,
+    pub next_mode_fallback: TraktorNextMode,
+    pub sync_mode: TraktorSyncMode,
 
     channel: Option<UnboundedSender<AppMessage>>,
 
@@ -66,9 +87,9 @@ impl Default for TraktorDataProvider {
             submitted_address: String::new(),
             channel: None,
 
-            next_mode: Some(TraktorNextMode::DeckByNumber),
-            next_mode_fallback: None,
-            sync_mode: None,
+            next_mode: TraktorNextMode::DeckByNumber,
+            next_mode_fallback: TraktorNextMode::None,
+            sync_mode: TraktorSyncMode::None,
 
             time_offset_ms: 0,
             state: None,
@@ -195,11 +216,11 @@ impl TraktorDataProvider {
         }
 
         self.cached_next_song_info = self
-            .try_get_next_with_mode(self.next_mode, channel, playlist)
-            .or_else(|| self.try_get_next_with_mode(self.next_mode_fallback, channel, playlist));
+            .try_get_next_with_mode(false, channel, playlist)
+            .or_else(|| self.try_get_next_with_mode(true, channel, playlist));
 
         match self.sync_mode {
-            Some(TraktorSyncMode::AbsoluteByNumber) => {
+            TraktorSyncMode::AbsoluteByNumber => {
                 let current_index = playlist
                     .iter()
                     .position(|s| content.number == s.track_number);
@@ -209,7 +230,7 @@ impl TraktorDataProvider {
                     Some(ci) => TraktorSyncAction::PlaylistAbsolute(ci),
                 };
             }
-            Some(TraktorSyncMode::AbsoluteByName) => {
+            TraktorSyncMode::AbsoluteByName => {
                 let current_index = playlist
                     .iter()
                     .position(|s| Self::songs_name_match(&current_song_info, s));
@@ -225,11 +246,15 @@ impl TraktorDataProvider {
 
     fn try_get_next_with_mode(
         &self,
-        mode: Option<TraktorNextMode>,
+        fallback: bool,
         current_channel: &ChannelState,
         playlist: &[SongInfo],
     ) -> Option<SongInfo> {
-        let mode = mode?;
+        let mode = if !fallback {
+            self.next_mode
+        } else {
+            self.next_mode_fallback
+        };
 
         if !self.is_ready() {
             return None;
@@ -283,6 +308,7 @@ impl TraktorDataProvider {
 
                 current_index.and_then(|ci| playlist.get(ci + 1).cloned())
             }
+            TraktorNextMode::None => None,
         }
     }
 
@@ -354,7 +380,7 @@ impl TraktorDataProvider {
             }
             ServerMessage::Update(update) => {
                 if let Some(state) = self.state.as_mut() {
-                    if matches!(self.sync_mode, Some(TraktorSyncMode::Relative))
+                    if matches!(self.sync_mode, TraktorSyncMode::Relative)
                         && let StateUpdate::Mixer(new_mixer_state) = &update
                     {
                         let x_fader_old = state.mixer.x_fader;

--- a/src/ui/config_window.rs
+++ b/src/ui/config_window.rs
@@ -1,5 +1,5 @@
 use crate::dataloading::dataprovider::song_data_provider::{
-    SongChange, SongDataEdit, SongDataSource,
+    SongChange, SongDataEdit, SongDataProvider, SongDataSource,
 };
 use crate::traktor_api::{TRAKTOR_SERVER_DEFAULT_ADDR, TraktorNextMode, TraktorSyncMode};
 use crate::ui::widget::dynamic_text_input::DynamicTextInput;
@@ -11,8 +11,8 @@ use iced::border::Radius;
 use iced::widget::scrollable::{Direction, RelativeOffset, Scrollbar};
 use iced::widget::space::horizontal;
 use iced::widget::{
-    Button, Column, ComboBox, Row, Scrollable, Space, button, checkbox, column as col, combo_box,
-    pick_list, radio, row, scrollable, text,
+    Button, Column, ComboBox, Container, Row, Scrollable, Space, button, checkbox, column as col,
+    combo_box, container, pick_list, radio, row, scrollable, text,
 };
 use iced::{
     Alignment, Animation, Border, Color, Element, Font, Length, Pixels, Renderer, Size, Theme,
@@ -33,8 +33,9 @@ pub struct ConfigWindow {
     pub size: Size,
     pub enable_autoscroll: bool,
     pub sidebar_state: Animation<bool>,
-    pub server_address_state: combo_box::State<String>,
+    pub server_address_text: String,
     pub theme: Theme,
+    server_address_presets: combo_box::State<String>,
 }
 
 pub static PLAYLIST_SCROLLABLE_ID: LazyLock<iced::widget::Id> =
@@ -49,9 +50,10 @@ impl Window for ConfigWindow {
 
             enable_autoscroll: true,
             sidebar_state: Animation::new(false)
-                .duration(Duration::from_millis(500))
+                .duration(Duration::from_millis(100))
                 .easing(animation::Easing::EaseInOut),
-            server_address_state: combo_box::State::default(),
+            server_address_presets: combo_box::State::default(),
+            server_address_text: String::new(),
             theme: Theme::Dark,
         }
     }
@@ -75,15 +77,14 @@ impl ConfigWindow {
         let playlist_view = self.build_playlist_view(dance_interpreter);
         let statics_view = self.build_statics_view(dance_interpreter);
 
-        let main_content = col![top_bar, playlist_view, statics_view];
-
         if self.sidebar_state.value() || self.sidebar_state.is_animating(Instant::now()) {
             let side_bar = self
                 .build_server_sidebar(dance_interpreter)
                 .width(self.sidebar_state.interpolate(0.0, 400.0, Instant::now()));
-            row![main_content, side_bar].into()
+            let main_content = row![col![top_bar, playlist_view], side_bar];
+            col![main_content, statics_view].spacing(5).into()
         } else {
-            main_content.into()
+            col![top_bar, playlist_view, statics_view].into()
         }
     }
 
@@ -125,7 +126,7 @@ impl ConfigWindow {
     fn build_server_sidebar<'a>(
         &'a self,
         dance_interpreter: &'a DanceInterpreter,
-    ) -> Column<'a, Message> {
+    ) -> Container<'a, Message> {
         let sync_options = vec![
             TraktorSyncMode::None,
             TraktorSyncMode::Relative,
@@ -141,80 +142,75 @@ impl ConfigWindow {
             TraktorNextMode::PlaylistByName,
         ];
 
-        col![
-            text("Server Settings").size(24),
-            labeled_message_checkbox(
-                "Enable Server",
-                dance_interpreter.data_provider.traktor_provider.is_enabled,
-                Message::TraktorEnableServer,
-            ),
-            labeled_dynamic_text_input(
-                "Server Address",
-                TRAKTOR_SERVER_DEFAULT_ADDR,
-                dance_interpreter
-                    .data_provider
-                    .traktor_provider
-                    .address
-                    .as_str(),
-                Message::TraktorChangeAddress,
-                Some(Message::TraktorSubmitAddress),
-            ),
+        container(
             col![
-                text("Network Interface:"),
-                self.get_network_interface_combo_box(dance_interpreter)
-            ],
-            labeled_message_checkbox(
-                "Enable Debug Logging",
-                dance_interpreter
-                    .data_provider
-                    .traktor_provider
-                    .debug_logging,
-                Message::TraktorEnableDebugLogging,
-            ),
-            label_message_button_fill_opt(
-                "Reset Connection",
-                dance_interpreter
-                    .data_provider
-                    .traktor_provider
-                    .is_enabled
-                    .then_some(Message::TraktorReconnect)
-            ),
-            col![
-                text("Sync Mode"),
-                pick_list(
-                    sync_options.clone(),
-                    Some(dance_interpreter.data_provider.traktor_provider.sync_mode),
-                    Message::TraktorSetSyncMode
-                )
-            ]
-            .align_x(Alignment::Center),
-            col![
-                text("Next Song Mode"),
-                pick_list(
-                    next_options.clone(),
-                    Some(dance_interpreter.data_provider.traktor_provider.next_mode),
-                    Message::TraktorSetNextMode
-                )
-            ]
-            .align_x(Alignment::Center),
-            col![
-                text("Next Song Mode (Fallback)"),
-                pick_list(
-                    next_options.clone(),
-                    Some(
-                        dance_interpreter
-                            .data_provider
-                            .traktor_provider
-                            .next_mode_fallback
-                    ),
-                    Message::TraktorSetNextModeFallback
-                )
+                text("Server Settings").size(24),
+                labeled_message_checkbox(
+                    "Enable Server",
+                    dance_interpreter.data_provider.traktor_provider.is_enabled,
+                    Message::TraktorEnableServer,
+                ),
+                col![
+                    text("Server Address: "),
+                    self.build_network_interface_combo_box(dance_interpreter)
+                ],
+                labeled_message_checkbox(
+                    "Enable Debug Logging",
+                    dance_interpreter
+                        .data_provider
+                        .traktor_provider
+                        .debug_logging,
+                    Message::TraktorEnableDebugLogging,
+                ),
+                label_message_button_fill_opt(
+                    "Reset Connection",
+                    dance_interpreter
+                        .data_provider
+                        .traktor_provider
+                        .is_enabled
+                        .then_some(Message::TraktorReconnect)
+                ),
+                col![
+                    text("Sync Mode"),
+                    pick_list(
+                        sync_options.clone(),
+                        Some(dance_interpreter.data_provider.traktor_provider.sync_mode),
+                        Message::TraktorSetSyncMode
+                    )
+                ]
+                .align_x(Alignment::Center),
+                col![
+                    text("Next Song Mode"),
+                    pick_list(
+                        next_options.clone(),
+                        Some(dance_interpreter.data_provider.traktor_provider.next_mode),
+                        Message::TraktorSetNextMode
+                    )
+                ]
+                .align_x(Alignment::Center),
+                col![
+                    text("Next Song Mode (Fallback)"),
+                    pick_list(
+                        next_options.clone(),
+                        Some(
+                            dance_interpreter
+                                .data_provider
+                                .traktor_provider
+                                .next_mode_fallback
+                        ),
+                        Message::TraktorSetNextModeFallback
+                    )
+                ]
+                .align_x(Alignment::Center)
             ]
             .align_x(Alignment::Center)
-        ]
-        .align_x(Alignment::Center)
-        .spacing(10)
-        .padding(10)
+            .spacing(10)
+            .padding(10),
+        )
+        .height(Length::Fill)
+        .style(|t| {
+            container::Style::default().background(t.extended_palette().background.weakest.color)
+        })
     }
 
     fn build_playlist_view(&'_ self, dance_interpreter: &DanceInterpreter) -> Column<'_, Message> {
@@ -354,7 +350,7 @@ impl ConfigWindow {
             material_icon_sized_message_button(
                 "right_panel_open",
                 20.0,
-                Message::ToggleRightSidebar
+                Message::Sidebar(SidebarMessage::Toggle)
             )
             .padding([0, 4])
         ]
@@ -409,7 +405,7 @@ impl ConfigWindow {
                         (
                             labeled_dynamic_text_input("Server Address", TRAKTOR_SERVER_DEFAULT_ADDR, dance_interpreter.data_provider.traktor_provider.address.as_str(),
                                 Message::TraktorChangeAddress, Some(Message::TraktorSubmitAddress)),
-                            menu_tpl_2(get_network_interface_menu(dance_interpreter).into_iter().map(Item::new).collect())
+                            menu_tpl_2(get_network_interface_menu(&dance_interpreter.data_provider).into_iter().map(Item::new).collect())
                         ),
                         (separator()),
                         (labeled_message_checkbox_opt("Enable Debug Logging", dance_interpreter.data_provider.traktor_provider.debug_logging,
@@ -483,22 +479,49 @@ impl ConfigWindow {
         mb
     }
 
-    fn get_network_interface_combo_box(
+    fn build_network_interface_combo_box(
         &'_ self,
         dance_interpreter: &DanceInterpreter,
     ) -> ComboBox<'_, String, Message> {
         combo_box::<String, _, Theme, Renderer>(
-            &self.server_address_state,
-            "Enter bind address",
-            Some(
-                &dance_interpreter
-                    .data_provider
-                    .traktor_provider
-                    .submitted_address,
-            ),
+            &self.server_address_presets,
+            if !self.server_address_text.is_empty() {
+                self.server_address_text.as_ref()
+            } else {
+                TRAKTOR_SERVER_DEFAULT_ADDR
+            },
+            Some(&dance_interpreter.data_provider.traktor_provider.address),
             Message::TraktorChangeAndSubmitAddress,
         )
+        .on_open(Message::Sidebar(SidebarMessage::UpdateAddressPresets))
+        .on_option_hovered(Message::TraktorChangeAddress)
+        .on_input(Message::TraktorChangeAddress)
+        .on_close(Message::TraktorSubmitAddress)
     }
+
+    pub fn update_network_interface_selection(&mut self, song_data_provider: &SongDataProvider) {
+        let mut detected_interfaces: Vec<String> =
+            get_formatted_network_interfaces(song_data_provider)
+                .into_iter()
+                .map(|(_, _, formatted)| formatted)
+                .collect();
+        detected_interfaces.push(TRAKTOR_SERVER_DEFAULT_ADDR.to_owned());
+        detected_interfaces.push(
+            song_data_provider
+                .traktor_provider
+                .submitted_address
+                .clone(),
+        );
+        detected_interfaces.sort();
+
+        self.server_address_presets = combo_box::State::new(detected_interfaces);
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum SidebarMessage {
+    Toggle,
+    UpdateAddressPresets,
 }
 
 fn get_network_interfaces() -> Vec<(String, String)> {
@@ -519,19 +542,27 @@ fn get_network_interfaces() -> Vec<(String, String)> {
     interfaces
 }
 
-fn get_network_interface_menu(dance_interpreter: &'_ DanceInterpreter) -> Vec<Button<'_, Message>> {
+fn get_formatted_network_interfaces(
+    song_data_provider: &'_ SongDataProvider,
+) -> Vec<(String, String, String)> {
     let interfaces = get_network_interfaces();
 
-    let original_addr = dance_interpreter
-        .data_provider
+    let original_addr = song_data_provider
         .traktor_provider
         .get_socket_addr()
         .unwrap_or(TRAKTOR_SERVER_DEFAULT_ADDR.parse().unwrap());
     let original_port = original_addr.port();
 
-    let interfaces = interfaces
+    interfaces
         .into_iter()
-        .map(|(name, addr)| (name, addr.clone(), format!("{}:{}", addr, original_port)));
+        .map(|(name, addr)| (name, addr.clone(), format!("{}:{}", addr, original_port)))
+        .collect()
+}
+
+fn get_network_interface_menu(
+    song_data_provider: &'_ SongDataProvider,
+) -> Vec<Button<'_, Message>> {
+    let interfaces = get_formatted_network_interfaces(song_data_provider);
 
     interfaces
         .into_iter()

--- a/src/ui/config_window.rs
+++ b/src/ui/config_window.rs
@@ -3,6 +3,7 @@ use crate::dataloading::dataprovider::song_data_provider::{
 };
 use crate::traktor_api::{TRAKTOR_SERVER_DEFAULT_ADDR, TraktorNextMode, TraktorSyncMode};
 use crate::ui::widget::dynamic_text_input::DynamicTextInput;
+use crate::ui::widget::power_button::PowerButton;
 use crate::ui::widget::suggestion_text_input;
 use crate::ui::widget::suggestion_text_input::SuggestionTextInput;
 use crate::ui::{material_icon, material_icon_sized};
@@ -13,8 +14,8 @@ use iced::border::Radius;
 use iced::widget::scrollable::{Direction, RelativeOffset, Scrollbar};
 use iced::widget::space::horizontal;
 use iced::widget::{
-    Button, Column, Container, Row, Scrollable, Space, button, checkbox, column as col, container,
-    pick_list, radio, row, scrollable, text,
+    Button, Column, Container, Row, Scrollable, Space, button, canvas, checkbox, column as col,
+    container, pick_list, radio, row, scrollable, text,
 };
 use iced::{
     Alignment, Animation, Border, Color, Element, Font, Length, Pixels, Renderer, Size, Theme,
@@ -36,6 +37,7 @@ pub struct ConfigWindow {
     pub sidebar_state: Animation<bool>,
     pub server_address_text: String,
     pub theme: Theme,
+    pub power_button_cache: canvas::Cache,
     server_address_presets: suggestion_text_input::State<String>,
 }
 
@@ -56,6 +58,7 @@ impl Window for ConfigWindow {
             server_address_presets: suggestion_text_input::State::default(),
             server_address_text: String::new(),
             theme: Theme::Dark,
+            power_button_cache: canvas::Cache::default(),
         }
     }
 
@@ -79,9 +82,13 @@ impl ConfigWindow {
         let statics_view = self.build_statics_view(dance_interpreter);
 
         if self.sidebar_state.value() || self.sidebar_state.is_animating(Instant::now()) {
-            let side_bar = self
-                .build_server_sidebar(dance_interpreter)
-                .width(self.sidebar_state.interpolate(0.0, 400.0, Instant::now()));
+            let side_bar =
+                self.build_server_sidebar(dance_interpreter)
+                    .width(self.sidebar_state.interpolate(
+                        0.0,
+                        (self.size.width / 5.0).max(400.0),
+                        Instant::now(),
+                    ));
             let main_content = row![col![top_bar, playlist_view], side_bar];
             col![main_content, statics_view].spacing(5).into()
         } else {
@@ -146,11 +153,16 @@ impl ConfigWindow {
         container(
             col![
                 text("Server Settings").size(24),
-                labeled_message_checkbox(
-                    "Enable Server",
-                    dance_interpreter.data_provider.traktor_provider.is_enabled,
-                    Message::TraktorEnableServer,
-                ),
+                col![
+                    canvas(
+                        PowerButton::new(
+                            dance_interpreter.data_provider.traktor_provider.is_enabled,
+                            &self.power_button_cache
+                        )
+                        .on_toggle(Message::TraktorEnableServer)
+                    ),
+                    text("Enable Server")
+                ],
                 col![
                     text("Server Address: "),
                     self.build_network_interface_combo_box(dance_interpreter)
@@ -349,7 +361,11 @@ impl ConfigWindow {
             self.build_menu_bar(dance_interpreter),
             horizontal(),
             material_icon_sized_message_button(
-                "right_panel_open",
+                if self.sidebar_state.value() {
+                    "right_panel_close"
+                } else {
+                    "right_panel_open"
+                },
                 20.0,
                 Message::Sidebar(SidebarMessage::Toggle)
             )
@@ -488,22 +504,6 @@ fn get_formatted_network_interfaces(
         .collect()
 }
 
-fn get_network_interface_menu(
-    song_data_provider: &'_ SongDataProvider,
-) -> Vec<Button<'_, Message>> {
-    let interfaces = get_formatted_network_interfaces(song_data_provider);
-
-    interfaces
-        .into_iter()
-        .map(|(name, addr, addr_with_port)| {
-            label_message_button_fill(
-                format!("{}: {}", name, addr),
-                Message::TraktorChangeAndSubmitAddress(addr_with_port),
-            )
-        })
-        .collect()
-}
-
 fn label_message_button_fill<'a>(
     label: impl text::IntoFragment<'a>,
     message: Message,
@@ -528,6 +528,7 @@ fn label_message_button<'a>(
         .on_press(message)
 }
 
+#[allow(dead_code)]
 fn submenu_button(label: &'_ str) -> Button<'_, Message, Theme, Renderer> {
     button(
         row![
@@ -589,6 +590,7 @@ fn labeled_message_checkbox(
     //.style(checkbox::secondary)
 }
 
+#[allow(dead_code)]
 fn labeled_message_radio<T: Copy + Eq>(
     label: &'_ str,
     value: T,
@@ -599,6 +601,7 @@ fn labeled_message_radio<T: Copy + Eq>(
     //.style(checkbox::secondary)
 }
 
+#[allow(dead_code)]
 fn labeled_message_checkbox_opt(
     label: &'_ str,
     checked: bool,
@@ -612,6 +615,7 @@ fn labeled_message_checkbox_opt(
     }
 }
 
+#[allow(dead_code)]
 fn labeled_dynamic_text_input<'a>(
     label: &'a str,
     placeholder: &'a str,

--- a/src/ui/config_window.rs
+++ b/src/ui/config_window.rs
@@ -2,10 +2,10 @@ use crate::dataloading::dataprovider::song_data_provider::{
     SongChange, SongDataEdit, SongDataProvider, SongDataSource,
 };
 use crate::traktor_api::{TRAKTOR_SERVER_DEFAULT_ADDR, TraktorNextMode, TraktorSyncMode};
+use crate::ui::widget::canvas_toggle::CanvasToggle;
 use crate::ui::widget::dynamic_text_input::DynamicTextInput;
-use crate::ui::widget::power_button::PowerButton;
-use crate::ui::widget::suggestion_text_input;
 use crate::ui::widget::suggestion_text_input::SuggestionTextInput;
+use crate::ui::widget::{power_button, suggestion_text_input};
 use crate::ui::{material_icon, material_icon_sized};
 use crate::{DanceInterpreter, Message, Window};
 use iced::advanced::Widget;
@@ -35,10 +35,22 @@ pub struct ConfigWindow {
     pub size: Size,
     pub enable_autoscroll: bool,
     pub sidebar_state: Animation<bool>,
+    pub bottombar_state: Animation<bool>,
     pub server_address_text: String,
     pub theme: Theme,
     pub power_button_cache: canvas::Cache,
     server_address_presets: suggestion_text_input::State<String>,
+}
+
+#[derive(Debug, Clone)]
+pub enum SidebarMessage {
+    Toggle,
+    UpdateAddressPresets,
+}
+
+#[derive(Debug, Clone)]
+pub enum BottomBarMessage {
+    Toggle,
 }
 
 pub static PLAYLIST_SCROLLABLE_ID: LazyLock<iced::widget::Id> =
@@ -53,6 +65,9 @@ impl Window for ConfigWindow {
 
             enable_autoscroll: true,
             sidebar_state: Animation::new(false)
+                .duration(Duration::from_millis(100))
+                .easing(animation::Easing::EaseInOut),
+            bottombar_state: Animation::new(false)
                 .duration(Duration::from_millis(100))
                 .easing(animation::Easing::EaseInOut),
             server_address_presets: suggestion_text_input::State::default(),
@@ -79,21 +94,22 @@ impl ConfigWindow {
     pub fn view<'a>(&'a self, dance_interpreter: &'a DanceInterpreter) -> Element<'a, Message> {
         let top_bar = self.build_top_bar(dance_interpreter);
         let playlist_view = self.build_playlist_view(dance_interpreter);
-        let statics_view = self.build_statics_view(dance_interpreter);
 
-        if self.sidebar_state.value() || self.sidebar_state.is_animating(Instant::now()) {
-            let side_bar =
-                self.build_server_sidebar(dance_interpreter)
-                    .width(self.sidebar_state.interpolate(
-                        0.0,
-                        (self.size.width / 5.0).max(400.0),
-                        Instant::now(),
-                    ));
-            let main_content = row![col![top_bar, playlist_view], side_bar];
-            col![main_content, statics_view].spacing(5).into()
-        } else {
-            col![top_bar, playlist_view, statics_view].into()
-        }
+        let side_bar =
+            self.build_server_sidebar(dance_interpreter)
+                .width(self.sidebar_state.interpolate(
+                    0.0,
+                    (self.size.width / 5.0).min(400.0),
+                    Instant::now(),
+                ));
+        let bottom_bar = self.build_statics_bottombar(dance_interpreter).height(
+            self.bottombar_state
+                .interpolate(60.0, self.size.height / 3.0, Instant::now()),
+        );
+
+        col![row![col![top_bar, playlist_view], side_bar], bottom_bar]
+            .spacing(5)
+            .into()
     }
 
     fn get_play_state(
@@ -131,6 +147,18 @@ impl ConfigWindow {
         (is_current, is_next, is_traktor, is_played)
     }
 
+    fn build_statics_bottombar<'a>(
+        &'a self,
+        dance_interpreter: &'a DanceInterpreter,
+    ) -> Container<'a, Message> {
+        container(self.build_statics_view(dance_interpreter))
+            .width(Length::Fill)
+            .style(|t: &Theme| {
+                container::Style::default()
+                    .background(t.extended_palette().background.weakest.color)
+            })
+    }
+
     fn build_server_sidebar<'a>(
         &'a self,
         dance_interpreter: &'a DanceInterpreter,
@@ -154,13 +182,12 @@ impl ConfigWindow {
             col![
                 text("Server Settings").size(24),
                 col![
-                    canvas(
-                        PowerButton::new(
-                            dance_interpreter.data_provider.traktor_provider.is_enabled,
-                            &self.power_button_cache
-                        )
-                        .on_toggle(Message::TraktorEnableServer)
-                    ),
+                    CanvasToggle::new(
+                        dance_interpreter.data_provider.traktor_provider.is_enabled,
+                        &self.power_button_cache
+                    )
+                    .on_toggle(Message::TraktorEnableServer)
+                    .on_draw(power_button::draw_power_button),
                     text("Enable Server")
                 ],
                 col![
@@ -326,6 +353,15 @@ impl ConfigWindow {
             style: font::Style::Normal,
         };
 
+        let btn_bottombar_extend = material_icon_sized_message_button(
+            if self.sidebar_state.value() {
+                "bottom_panel_close"
+            } else {
+                "bottom_panel_open"
+            },
+            20.0,
+            Message::Bottombar(BottomBarMessage::Toggle),
+        );
         let btn_blank: Button<Message> =
             button(text("Blank").align_y(Vertical::Center).font(bold_font))
                 .style(button::secondary)
@@ -346,9 +382,9 @@ impl ConfigWindow {
                     .into()
             })
             .collect();
-
-        statics.insert(0, btn_blank.into());
-        statics.insert(1, btn_traktor.into());
+        statics.insert(0, btn_bottombar_extend.into());
+        statics.insert(1, btn_blank.into());
+        statics.insert(2, btn_traktor.into());
 
         scrollable(row(statics).spacing(5))
             .direction(Direction::Horizontal(Scrollbar::new()))
@@ -461,12 +497,6 @@ impl ConfigWindow {
             Some(&song_data_provider.traktor_provider.address.clone()),
         );
     }
-}
-
-#[derive(Debug, Clone)]
-pub enum SidebarMessage {
-    Toggle,
-    UpdateAddressPresets,
 }
 
 fn get_network_interfaces() -> Vec<(String, String)> {

--- a/src/ui/config_window.rs
+++ b/src/ui/config_window.rs
@@ -2,18 +2,22 @@ use crate::dataloading::dataprovider::song_data_provider::{
     SongChange, SongDataEdit, SongDataSource,
 };
 use crate::traktor_api::{TRAKTOR_SERVER_DEFAULT_ADDR, TraktorNextMode, TraktorSyncMode};
-use crate::ui::material_icon;
 use crate::ui::widget::dynamic_text_input::DynamicTextInput;
+use crate::ui::{material_icon, material_icon_sized};
 use crate::{DanceInterpreter, Message, Window};
 use iced::advanced::Widget;
 use iced::alignment::Vertical;
 use iced::border::Radius;
 use iced::widget::scrollable::{Direction, RelativeOffset, Scrollbar};
+use iced::widget::space::horizontal;
 use iced::widget::{
     Button, Column, Row, Scrollable, Space, button, checkbox, column as col, radio, row,
     scrollable, text,
 };
-use iced::{Border, Color, Element, Font, Length, Renderer, Size, Theme, font, window};
+use iced::{
+    Animation, Border, Color, Element, Font, Length, Pixels, Renderer, Size, Theme, animation,
+    font, window,
+};
 use iced_aw::menu::Item;
 use iced_aw::style::{Status, menu_bar::primary};
 use iced_aw::widget::InnerBounds;
@@ -21,13 +25,14 @@ use iced_aw::{Menu, MenuBar, iced_aw_font, menu, menu_bar, menu_items, quad};
 use network_interface::Addr::V4;
 use network_interface::{NetworkInterface, NetworkInterfaceConfig};
 use std::sync::LazyLock;
+use std::time::{Duration, Instant};
 
 pub struct ConfigWindow {
     pub id: window::Id,
     pub closed: bool,
     pub size: Size,
-
     pub enable_autoscroll: bool,
+    pub sidebar_slidein: Animation<bool>,
     pub theme: Theme,
 }
 
@@ -42,6 +47,9 @@ impl Window for ConfigWindow {
             size: Size::default(),
 
             enable_autoscroll: true,
+            sidebar_slidein: Animation::new(false)
+                .duration(Duration::from_secs(5))
+                .easing(animation::Easing::EaseInOut),
             theme: Theme::Dark,
         }
     }
@@ -61,11 +69,11 @@ impl Window for ConfigWindow {
 
 impl ConfigWindow {
     pub fn view<'a>(&'a self, dance_interpreter: &'a DanceInterpreter) -> Element<'a, Message> {
-        let menu_bar = self.build_menu_bar(dance_interpreter);
+        let top_bar = self.build_top_bar(dance_interpreter);
         let playlist_view = self.build_playlist_view(dance_interpreter);
         let statics_view = self.build_statics_view(dance_interpreter);
 
-        let content = col![menu_bar, playlist_view, statics_view];
+        let content = col![top_bar, playlist_view, statics_view];
         content.into()
     }
 
@@ -232,6 +240,19 @@ impl ConfigWindow {
             .direction(Direction::Horizontal(Scrollbar::new()))
             .spacing(5)
             .width(Length::Fill)
+    }
+
+    fn build_top_bar<'a>(&self, dance_interpreter: &'a DanceInterpreter) -> Row<'a, Message> {
+        row![
+            self.build_menu_bar(dance_interpreter),
+            horizontal(),
+            material_icon_sized_message_button(
+                "right_panel_open",
+                self.sidebar_slidein.interpolate(10.0, 40.0, Instant::now()),
+                Message::ToggleRightSidebar
+            )
+            .padding([0, 4])
+        ]
     }
 
     fn build_menu_bar<'a>(
@@ -420,7 +441,18 @@ fn label_message_button_fill_opt(
 
 fn material_icon_message_button(icon_id: &'_ str, message: Message) -> button::Button<'_, Message> {
     button(material_icon(icon_id))
-        .padding([4, 8])
+        //.padding([4, 8])
+        .style(button::secondary)
+        .on_press(message)
+        .width(Length::Shrink)
+}
+
+fn material_icon_sized_message_button(
+    icon_id: &'_ str,
+    size: impl Into<Pixels>,
+    message: Message,
+) -> button::Button<'_, Message> {
+    button(material_icon_sized(icon_id, size))
         .style(button::secondary)
         .on_press(message)
         .width(Length::Shrink)

--- a/src/ui/config_window.rs
+++ b/src/ui/config_window.rs
@@ -11,12 +11,12 @@ use iced::border::Radius;
 use iced::widget::scrollable::{Direction, RelativeOffset, Scrollbar};
 use iced::widget::space::horizontal;
 use iced::widget::{
-    Button, Column, Row, Scrollable, Space, button, checkbox, column as col, radio, row,
-    scrollable, text,
+    Button, Column, ComboBox, Row, Scrollable, Space, button, checkbox, column as col, combo_box,
+    pick_list, radio, row, scrollable, text,
 };
 use iced::{
-    Animation, Border, Color, Element, Font, Length, Pixels, Renderer, Size, Theme, animation,
-    font, window,
+    Alignment, Animation, Border, Color, Element, Font, Length, Pixels, Renderer, Size, Theme,
+    animation, font, window,
 };
 use iced_aw::menu::Item;
 use iced_aw::style::{Status, menu_bar::primary};
@@ -32,7 +32,8 @@ pub struct ConfigWindow {
     pub closed: bool,
     pub size: Size,
     pub enable_autoscroll: bool,
-    pub sidebar_slidein: Animation<bool>,
+    pub sidebar_state: Animation<bool>,
+    pub server_address_state: combo_box::State<String>,
     pub theme: Theme,
 }
 
@@ -47,9 +48,10 @@ impl Window for ConfigWindow {
             size: Size::default(),
 
             enable_autoscroll: true,
-            sidebar_slidein: Animation::new(false)
-                .duration(Duration::from_secs(5))
+            sidebar_state: Animation::new(false)
+                .duration(Duration::from_millis(500))
                 .easing(animation::Easing::EaseInOut),
+            server_address_state: combo_box::State::default(),
             theme: Theme::Dark,
         }
     }
@@ -73,8 +75,16 @@ impl ConfigWindow {
         let playlist_view = self.build_playlist_view(dance_interpreter);
         let statics_view = self.build_statics_view(dance_interpreter);
 
-        let content = col![top_bar, playlist_view, statics_view];
-        content.into()
+        let main_content = col![top_bar, playlist_view, statics_view];
+
+        if self.sidebar_state.value() || self.sidebar_state.is_animating(Instant::now()) {
+            let side_bar = self
+                .build_server_sidebar(dance_interpreter)
+                .width(self.sidebar_state.interpolate(0.0, 400.0, Instant::now()));
+            row![main_content, side_bar].into()
+        } else {
+            main_content.into()
+        }
     }
 
     fn get_play_state(
@@ -110,6 +120,101 @@ impl ConfigWindow {
         }
 
         (is_current, is_next, is_traktor, is_played)
+    }
+
+    fn build_server_sidebar<'a>(
+        &'a self,
+        dance_interpreter: &'a DanceInterpreter,
+    ) -> Column<'a, Message> {
+        let sync_options = vec![
+            TraktorSyncMode::None,
+            TraktorSyncMode::Relative,
+            TraktorSyncMode::AbsoluteByNumber,
+            TraktorSyncMode::AbsoluteByName,
+        ];
+
+        let next_options = vec![
+            TraktorNextMode::None,
+            TraktorNextMode::DeckByPosition,
+            TraktorNextMode::DeckByNumber,
+            TraktorNextMode::PlaylistByNumber,
+            TraktorNextMode::PlaylistByName,
+        ];
+
+        col![
+            text("Server Settings").size(24),
+            labeled_message_checkbox(
+                "Enable Server",
+                dance_interpreter.data_provider.traktor_provider.is_enabled,
+                Message::TraktorEnableServer,
+            ),
+            labeled_dynamic_text_input(
+                "Server Address",
+                TRAKTOR_SERVER_DEFAULT_ADDR,
+                dance_interpreter
+                    .data_provider
+                    .traktor_provider
+                    .address
+                    .as_str(),
+                Message::TraktorChangeAddress,
+                Some(Message::TraktorSubmitAddress),
+            ),
+            col![
+                text("Network Interface:"),
+                self.get_network_interface_combo_box(dance_interpreter)
+            ],
+            labeled_message_checkbox(
+                "Enable Debug Logging",
+                dance_interpreter
+                    .data_provider
+                    .traktor_provider
+                    .debug_logging,
+                Message::TraktorEnableDebugLogging,
+            ),
+            label_message_button_fill_opt(
+                "Reset Connection",
+                dance_interpreter
+                    .data_provider
+                    .traktor_provider
+                    .is_enabled
+                    .then_some(Message::TraktorReconnect)
+            ),
+            col![
+                text("Sync Mode"),
+                pick_list(
+                    sync_options.clone(),
+                    Some(dance_interpreter.data_provider.traktor_provider.sync_mode),
+                    Message::TraktorSetSyncMode
+                )
+            ]
+            .align_x(Alignment::Center),
+            col![
+                text("Next Song Mode"),
+                pick_list(
+                    next_options.clone(),
+                    Some(dance_interpreter.data_provider.traktor_provider.next_mode),
+                    Message::TraktorSetNextMode
+                )
+            ]
+            .align_x(Alignment::Center),
+            col![
+                text("Next Song Mode (Fallback)"),
+                pick_list(
+                    next_options.clone(),
+                    Some(
+                        dance_interpreter
+                            .data_provider
+                            .traktor_provider
+                            .next_mode_fallback
+                    ),
+                    Message::TraktorSetNextModeFallback
+                )
+            ]
+            .align_x(Alignment::Center)
+        ]
+        .align_x(Alignment::Center)
+        .spacing(10)
+        .padding(10)
     }
 
     fn build_playlist_view(&'_ self, dance_interpreter: &DanceInterpreter) -> Column<'_, Message> {
@@ -248,7 +353,7 @@ impl ConfigWindow {
             horizontal(),
             material_icon_sized_message_button(
                 "right_panel_open",
-                self.sidebar_slidein.interpolate(10.0, 40.0, Instant::now()),
+                20.0,
                 Message::ToggleRightSidebar
             )
             .padding([0, 4])
@@ -304,7 +409,7 @@ impl ConfigWindow {
                         (
                             labeled_dynamic_text_input("Server Address", TRAKTOR_SERVER_DEFAULT_ADDR, dance_interpreter.data_provider.traktor_provider.address.as_str(),
                                 Message::TraktorChangeAddress, Some(Message::TraktorSubmitAddress)),
-                            menu_tpl_2(get_network_interface_menu(dance_interpreter))
+                            menu_tpl_2(get_network_interface_menu(dance_interpreter).into_iter().map(Item::new).collect())
                         ),
                         (separator()),
                         (labeled_message_checkbox_opt("Enable Debug Logging", dance_interpreter.data_provider.traktor_provider.debug_logging,
@@ -315,14 +420,14 @@ impl ConfigWindow {
                             submenu_button("Sync Mode"),
                             menu_tpl_2(
                                 menu_items!(
-                                    (labeled_message_radio("None", true,
-                                        Some(dance_interpreter.data_provider.traktor_provider.sync_mode.is_none()), |_| Message::TraktorSetSyncMode(None))),
+                                    (labeled_message_radio("None", TraktorSyncMode::None,
+                                        dance_interpreter.data_provider.traktor_provider.sync_mode, Message::TraktorSetSyncMode)),
                                     (labeled_message_radio("X Fader", TraktorSyncMode::Relative,
-                                        dance_interpreter.data_provider.traktor_provider.sync_mode, |v| Message::TraktorSetSyncMode(Some(v)))),
+                                        dance_interpreter.data_provider.traktor_provider.sync_mode, Message::TraktorSetSyncMode)),
                                     (labeled_message_radio("By Track Number", TraktorSyncMode::AbsoluteByNumber,
-                                        dance_interpreter.data_provider.traktor_provider.sync_mode, |v| Message::TraktorSetSyncMode(Some(v)))),
+                                        dance_interpreter.data_provider.traktor_provider.sync_mode, Message::TraktorSetSyncMode)),
                                     (labeled_message_radio("By Title / Artist", TraktorSyncMode::AbsoluteByName,
-                                        dance_interpreter.data_provider.traktor_provider.sync_mode, |v| Message::TraktorSetSyncMode(Some(v)))),
+                                        dance_interpreter.data_provider.traktor_provider.sync_mode, Message::TraktorSetSyncMode)),
                                 )
                             )
                         ),
@@ -330,16 +435,16 @@ impl ConfigWindow {
                             submenu_button("Next Song Mode"),
                             menu_tpl_2(
                                 menu_items!(
-                                    (labeled_message_radio("None", true,
-                                        Some(dance_interpreter.data_provider.traktor_provider.next_mode.is_none()), |_| Message::TraktorSetNextMode(None))),
+                                    (labeled_message_radio("None", TraktorNextMode::None,
+                                        dance_interpreter.data_provider.traktor_provider.next_mode, Message::TraktorSetNextMode)),
                                     (labeled_message_radio("From other Deck (by Position)", TraktorNextMode::DeckByPosition,
-                                        dance_interpreter.data_provider.traktor_provider.next_mode, |v| Message::TraktorSetNextMode(Some(v)))),
+                                        dance_interpreter.data_provider.traktor_provider.next_mode, Message::TraktorSetNextMode)),
                                     (labeled_message_radio("From other Deck (by Track Number)", TraktorNextMode::DeckByNumber,
-                                        dance_interpreter.data_provider.traktor_provider.next_mode, |v| Message::TraktorSetNextMode(Some(v)))),
+                                        dance_interpreter.data_provider.traktor_provider.next_mode, Message::TraktorSetNextMode)),
                                     (labeled_message_radio("From Playlist (by Track Number)", TraktorNextMode::PlaylistByNumber,
-                                        dance_interpreter.data_provider.traktor_provider.next_mode, |v| Message::TraktorSetNextMode(Some(v)))),
+                                        dance_interpreter.data_provider.traktor_provider.next_mode, Message::TraktorSetNextMode)),
                                     (labeled_message_radio("From Playlist (by Title / Artist)", TraktorNextMode::PlaylistByName,
-                                        dance_interpreter.data_provider.traktor_provider.next_mode, |v| Message::TraktorSetNextMode(Some(v)))),
+                                        dance_interpreter.data_provider.traktor_provider.next_mode, Message::TraktorSetNextMode)),
                                 )
                             )
                         ),
@@ -347,16 +452,16 @@ impl ConfigWindow {
                             submenu_button("Next Song Mode (Fallback)"),
                             menu_tpl_2(
                                 menu_items!(
-                                    (labeled_message_radio("None", true,
-                                        Some(dance_interpreter.data_provider.traktor_provider.next_mode_fallback.is_none()), |_| Message::TraktorSetNextModeFallback(None))),
+                                    (labeled_message_radio("None", TraktorNextMode::None,
+                                        dance_interpreter.data_provider.traktor_provider.next_mode_fallback, Message::TraktorSetNextModeFallback)),
                                     (labeled_message_radio("From other Deck (by Position)", TraktorNextMode::DeckByPosition,
-                                        dance_interpreter.data_provider.traktor_provider.next_mode_fallback, |v| Message::TraktorSetNextModeFallback(Some(v)))),
+                                        dance_interpreter.data_provider.traktor_provider.next_mode_fallback, Message::TraktorSetNextModeFallback)),
                                     (labeled_message_radio("From other Deck (by Track Number)", TraktorNextMode::DeckByNumber,
-                                        dance_interpreter.data_provider.traktor_provider.next_mode_fallback, |v| Message::TraktorSetNextModeFallback(Some(v)))),
+                                        dance_interpreter.data_provider.traktor_provider.next_mode_fallback, Message::TraktorSetNextModeFallback)),
                                     (labeled_message_radio("From Playlist (by Track Number)", TraktorNextMode::PlaylistByNumber,
-                                        dance_interpreter.data_provider.traktor_provider.next_mode_fallback, |v| Message::TraktorSetNextModeFallback(Some(v)))),
+                                        dance_interpreter.data_provider.traktor_provider.next_mode_fallback, Message::TraktorSetNextModeFallback)),
                                     (labeled_message_radio("From Playlist (by Title / Artist)", TraktorNextMode::PlaylistByName,
-                                        dance_interpreter.data_provider.traktor_provider.next_mode_fallback, |v| Message::TraktorSetNextModeFallback(Some(v)))),
+                                        dance_interpreter.data_provider.traktor_provider.next_mode_fallback, Message::TraktorSetNextModeFallback)),
                                 )
                             )
                         )
@@ -367,7 +472,7 @@ impl ConfigWindow {
         )
         .spacing(5.0)
         .draw_path(menu::DrawPath::Backdrop)
-            .style(|theme:&iced::Theme, status: Status | menu::Style{
+            .style(|theme:&Theme, status: Status | menu::Style{
                 path_border: Border{
                     radius: Radius::new(6.0),
                     ..Default::default()
@@ -377,33 +482,93 @@ impl ConfigWindow {
 
         mb
     }
+
+    fn get_network_interface_combo_box(
+        &'_ self,
+        dance_interpreter: &DanceInterpreter,
+    ) -> ComboBox<'_, String, Message> {
+        combo_box::<String, _, Theme, Renderer>(
+            &self.server_address_state,
+            "Enter bind address",
+            Some(
+                &dance_interpreter
+                    .data_provider
+                    .traktor_provider
+                    .submitted_address,
+            ),
+            Message::TraktorChangeAndSubmitAddress,
+        )
+    }
+}
+
+fn get_network_interfaces() -> Vec<(String, String)> {
+    let mut interfaces = vec![("any".to_owned(), "0.0.0.0".to_owned())];
+
+    if let Ok(network_interfaces) = NetworkInterface::show() {
+        for i in network_interfaces {
+            for addr in i.addr {
+                let V4(ipv4_addr) = addr else {
+                    continue;
+                };
+
+                interfaces.push((i.name.clone(), ipv4_addr.ip.to_string()));
+            }
+        }
+    }
+
+    interfaces
+}
+
+fn get_network_interface_menu(dance_interpreter: &'_ DanceInterpreter) -> Vec<Button<'_, Message>> {
+    let interfaces = get_network_interfaces();
+
+    let original_addr = dance_interpreter
+        .data_provider
+        .traktor_provider
+        .get_socket_addr()
+        .unwrap_or(TRAKTOR_SERVER_DEFAULT_ADDR.parse().unwrap());
+    let original_port = original_addr.port();
+
+    let interfaces = interfaces
+        .into_iter()
+        .map(|(name, addr)| (name, addr.clone(), format!("{}:{}", addr, original_port)));
+
+    interfaces
+        .into_iter()
+        .map(|(name, addr, addr_with_port)| {
+            label_message_button_fill(
+                format!("{}: {}", name, addr),
+                Message::TraktorChangeAndSubmitAddress(addr_with_port),
+            )
+        })
+        .collect()
 }
 
 fn label_message_button_fill<'a>(
     label: impl text::IntoFragment<'a>,
     message: Message,
-) -> button::Button<'a, Message> {
+) -> Button<'a, Message> {
     label_message_button(label, message).width(Length::Fill)
 }
 
 fn label_message_button_shrink<'a>(
     label: impl text::IntoFragment<'a>,
     message: Message,
-) -> button::Button<'a, Message> {
+) -> Button<'a, Message> {
     label_message_button(label, message).width(Length::Shrink)
 }
 
 fn label_message_button<'a>(
     label: impl text::IntoFragment<'a>,
     message: Message,
-) -> button::Button<'a, Message> {
+) -> Button<'a, Message> {
     button(text(label).align_y(Vertical::Center))
         .padding([4, 8])
         .style(button::secondary)
         .on_press(message)
 }
 
-fn submenu_button(label: &'_ str) -> button::Button<'_, Message, iced::Theme, iced::Renderer> {
+fn submenu_button(label: &'_ str) -> Button<'_, Message, Theme, Renderer> {
     button(
         row![
             text(label).width(Length::Fill).align_y(Vertical::Center),
@@ -411,7 +576,7 @@ fn submenu_button(label: &'_ str) -> button::Button<'_, Message, iced::Theme, ic
                 .width(Length::Shrink)
                 .align_y(Vertical::Center),
         ]
-        .align_y(iced::Alignment::Center),
+        .align_y(Alignment::Center),
     )
     .padding([4, 8])
     .style(button::text)
@@ -419,10 +584,7 @@ fn submenu_button(label: &'_ str) -> button::Button<'_, Message, iced::Theme, ic
     .width(Length::Fill)
 }
 
-fn label_message_button_opt(
-    label: &'_ str,
-    message: Option<Message>,
-) -> button::Button<'_, Message> {
+fn label_message_button_opt(label: &'_ str, message: Option<Message>) -> Button<'_, Message> {
     if let Some(message) = message {
         label_message_button(label, message)
     } else {
@@ -432,14 +594,11 @@ fn label_message_button_opt(
     }
 }
 
-fn label_message_button_fill_opt(
-    label: &'_ str,
-    message: Option<Message>,
-) -> button::Button<'_, Message> {
+fn label_message_button_fill_opt(label: &'_ str, message: Option<Message>) -> Button<'_, Message> {
     label_message_button_opt(label, message).width(Length::Fill)
 }
 
-fn material_icon_message_button(icon_id: &'_ str, message: Message) -> button::Button<'_, Message> {
+fn material_icon_message_button(icon_id: &'_ str, message: Message) -> Button<'_, Message> {
     button(material_icon(icon_id))
         //.padding([4, 8])
         .style(button::secondary)
@@ -451,7 +610,7 @@ fn material_icon_sized_message_button(
     icon_id: &'_ str,
     size: impl Into<Pixels>,
     message: Message,
-) -> button::Button<'_, Message> {
+) -> Button<'_, Message> {
     button(material_icon_sized(icon_id, size))
         .style(button::secondary)
         .on_press(message)
@@ -473,10 +632,10 @@ fn labeled_message_checkbox(
 fn labeled_message_radio<T: Copy + Eq>(
     label: &'_ str,
     value: T,
-    selection: Option<T>,
+    selection: T,
     message: fn(T) -> Message,
 ) -> radio::Radio<'_, Message> {
-    radio(label, value, selection, message).width(Length::Fill)
+    radio(label, value, Some(selection), message).width(Length::Fill)
     //.style(checkbox::secondary)
 }
 
@@ -523,43 +682,4 @@ fn separator() -> quad::Quad {
         width: Length::Fill,
         ..Default::default()
     }
-}
-
-fn get_network_interface_menu(
-    dance_interpreter: &'_ DanceInterpreter,
-) -> Vec<Item<'_, Message, Theme, Renderer>> {
-    let mut interfaces = vec![("any".to_owned(), "0.0.0.0".to_owned())];
-
-    if let Ok(network_interfaces) = NetworkInterface::show() {
-        for i in network_interfaces {
-            for addr in i.addr {
-                let V4(ipv4_addr) = addr else {
-                    continue;
-                };
-
-                interfaces.push((i.name.clone(), ipv4_addr.ip.to_string()));
-            }
-        }
-    }
-
-    let original_addr = dance_interpreter
-        .data_provider
-        .traktor_provider
-        .get_socket_addr()
-        .unwrap_or(TRAKTOR_SERVER_DEFAULT_ADDR.parse().unwrap());
-    let original_port = original_addr.port();
-
-    let interfaces = interfaces
-        .into_iter()
-        .map(|(name, addr)| (name, addr.clone(), format!("{}:{}", addr, original_port)));
-
-    interfaces
-        .into_iter()
-        .map(|(name, addr, addr_with_port)| {
-            Item::new(label_message_button_fill(
-                format!("{}: {}", name, addr),
-                Message::TraktorChangeAndSubmitAddress(addr_with_port),
-            ))
-        })
-        .collect()
 }

--- a/src/ui/config_window.rs
+++ b/src/ui/config_window.rs
@@ -3,6 +3,8 @@ use crate::dataloading::dataprovider::song_data_provider::{
 };
 use crate::traktor_api::{TRAKTOR_SERVER_DEFAULT_ADDR, TraktorNextMode, TraktorSyncMode};
 use crate::ui::widget::dynamic_text_input::DynamicTextInput;
+use crate::ui::widget::suggestion_text_input;
+use crate::ui::widget::suggestion_text_input::SuggestionTextInput;
 use crate::ui::{material_icon, material_icon_sized};
 use crate::{DanceInterpreter, Message, Window};
 use iced::advanced::Widget;
@@ -11,14 +13,13 @@ use iced::border::Radius;
 use iced::widget::scrollable::{Direction, RelativeOffset, Scrollbar};
 use iced::widget::space::horizontal;
 use iced::widget::{
-    Button, Column, ComboBox, Container, Row, Scrollable, Space, button, checkbox, column as col,
-    combo_box, container, pick_list, radio, row, scrollable, text,
+    Button, Column, Container, Row, Scrollable, Space, button, checkbox, column as col, container,
+    pick_list, radio, row, scrollable, text,
 };
 use iced::{
     Alignment, Animation, Border, Color, Element, Font, Length, Pixels, Renderer, Size, Theme,
     animation, font, window,
 };
-use iced_aw::menu::Item;
 use iced_aw::style::{Status, menu_bar::primary};
 use iced_aw::widget::InnerBounds;
 use iced_aw::{Menu, MenuBar, iced_aw_font, menu, menu_bar, menu_items, quad};
@@ -35,7 +36,7 @@ pub struct ConfigWindow {
     pub sidebar_state: Animation<bool>,
     pub server_address_text: String,
     pub theme: Theme,
-    server_address_presets: combo_box::State<String>,
+    server_address_presets: suggestion_text_input::State<String>,
 }
 
 pub static PLAYLIST_SCROLLABLE_ID: LazyLock<iced::widget::Id> =
@@ -52,7 +53,7 @@ impl Window for ConfigWindow {
             sidebar_state: Animation::new(false)
                 .duration(Duration::from_millis(100))
                 .easing(animation::Easing::EaseInOut),
-            server_address_presets: combo_box::State::default(),
+            server_address_presets: suggestion_text_input::State::default(),
             server_address_text: String::new(),
             theme: Theme::Dark,
         }
@@ -361,7 +362,6 @@ impl ConfigWindow {
         dance_interpreter: &'a DanceInterpreter,
     ) -> MenuBar<'a, Message, Theme, Renderer> {
         let menu_tpl_1 = |items| Menu::new(items).max_width(150.0).offset(15.0).spacing(5.0);
-        let menu_tpl_2 = |items| Menu::new(items).max_width(150.0).offset(0.0).spacing(5.0);
 
         #[rustfmt::skip]
         let mb = menu_bar!
@@ -396,74 +396,6 @@ impl ConfigWindow {
                     )
                 )
                 .spacing(5.0)
-            ),
-            (
-                label_message_button_shrink("Traktor", Message::Noop),
-                menu_tpl_1(
-                    menu_items!(
-                        (labeled_message_checkbox("Enable Server", dance_interpreter.data_provider.traktor_provider.is_enabled, Message::TraktorEnableServer)),
-                        (
-                            labeled_dynamic_text_input("Server Address", TRAKTOR_SERVER_DEFAULT_ADDR, dance_interpreter.data_provider.traktor_provider.address.as_str(),
-                                Message::TraktorChangeAddress, Some(Message::TraktorSubmitAddress)),
-                            menu_tpl_2(get_network_interface_menu(&dance_interpreter.data_provider).into_iter().map(Item::new).collect())
-                        ),
-                        (separator()),
-                        (labeled_message_checkbox_opt("Enable Debug Logging", dance_interpreter.data_provider.traktor_provider.debug_logging,
-                            dance_interpreter.data_provider.traktor_provider.is_enabled.then_some(Message::TraktorEnableDebugLogging))),
-                        (label_message_button_fill_opt("Reset Connection", dance_interpreter.data_provider.traktor_provider.is_enabled.then_some(Message::TraktorReconnect))),
-                        (separator()),
-                        (
-                            submenu_button("Sync Mode"),
-                            menu_tpl_2(
-                                menu_items!(
-                                    (labeled_message_radio("None", TraktorSyncMode::None,
-                                        dance_interpreter.data_provider.traktor_provider.sync_mode, Message::TraktorSetSyncMode)),
-                                    (labeled_message_radio("X Fader", TraktorSyncMode::Relative,
-                                        dance_interpreter.data_provider.traktor_provider.sync_mode, Message::TraktorSetSyncMode)),
-                                    (labeled_message_radio("By Track Number", TraktorSyncMode::AbsoluteByNumber,
-                                        dance_interpreter.data_provider.traktor_provider.sync_mode, Message::TraktorSetSyncMode)),
-                                    (labeled_message_radio("By Title / Artist", TraktorSyncMode::AbsoluteByName,
-                                        dance_interpreter.data_provider.traktor_provider.sync_mode, Message::TraktorSetSyncMode)),
-                                )
-                            )
-                        ),
-                        (
-                            submenu_button("Next Song Mode"),
-                            menu_tpl_2(
-                                menu_items!(
-                                    (labeled_message_radio("None", TraktorNextMode::None,
-                                        dance_interpreter.data_provider.traktor_provider.next_mode, Message::TraktorSetNextMode)),
-                                    (labeled_message_radio("From other Deck (by Position)", TraktorNextMode::DeckByPosition,
-                                        dance_interpreter.data_provider.traktor_provider.next_mode, Message::TraktorSetNextMode)),
-                                    (labeled_message_radio("From other Deck (by Track Number)", TraktorNextMode::DeckByNumber,
-                                        dance_interpreter.data_provider.traktor_provider.next_mode, Message::TraktorSetNextMode)),
-                                    (labeled_message_radio("From Playlist (by Track Number)", TraktorNextMode::PlaylistByNumber,
-                                        dance_interpreter.data_provider.traktor_provider.next_mode, Message::TraktorSetNextMode)),
-                                    (labeled_message_radio("From Playlist (by Title / Artist)", TraktorNextMode::PlaylistByName,
-                                        dance_interpreter.data_provider.traktor_provider.next_mode, Message::TraktorSetNextMode)),
-                                )
-                            )
-                        ),
-                        (
-                            submenu_button("Next Song Mode (Fallback)"),
-                            menu_tpl_2(
-                                menu_items!(
-                                    (labeled_message_radio("None", TraktorNextMode::None,
-                                        dance_interpreter.data_provider.traktor_provider.next_mode_fallback, Message::TraktorSetNextModeFallback)),
-                                    (labeled_message_radio("From other Deck (by Position)", TraktorNextMode::DeckByPosition,
-                                        dance_interpreter.data_provider.traktor_provider.next_mode_fallback, Message::TraktorSetNextModeFallback)),
-                                    (labeled_message_radio("From other Deck (by Track Number)", TraktorNextMode::DeckByNumber,
-                                        dance_interpreter.data_provider.traktor_provider.next_mode_fallback, Message::TraktorSetNextModeFallback)),
-                                    (labeled_message_radio("From Playlist (by Track Number)", TraktorNextMode::PlaylistByNumber,
-                                        dance_interpreter.data_provider.traktor_provider.next_mode_fallback, Message::TraktorSetNextModeFallback)),
-                                    (labeled_message_radio("From Playlist (by Title / Artist)", TraktorNextMode::PlaylistByName,
-                                        dance_interpreter.data_provider.traktor_provider.next_mode_fallback, Message::TraktorSetNextModeFallback)),
-                                )
-                            )
-                        )
-                    )
-                )
-                .spacing(5.0)
             )
         )
         .spacing(5.0)
@@ -482,8 +414,8 @@ impl ConfigWindow {
     fn build_network_interface_combo_box(
         &'_ self,
         dance_interpreter: &DanceInterpreter,
-    ) -> ComboBox<'_, String, Message> {
-        combo_box::<String, _, Theme, Renderer>(
+    ) -> SuggestionTextInput<'_, String, Message> {
+        SuggestionTextInput::new(
             &self.server_address_presets,
             if !self.server_address_text.is_empty() {
                 self.server_address_text.as_ref()
@@ -506,15 +438,12 @@ impl ConfigWindow {
                 .map(|(_, _, formatted)| formatted)
                 .collect();
         detected_interfaces.push(TRAKTOR_SERVER_DEFAULT_ADDR.to_owned());
-        detected_interfaces.push(
-            song_data_provider
-                .traktor_provider
-                .submitted_address
-                .clone(),
-        );
         detected_interfaces.sort();
 
-        self.server_address_presets = combo_box::State::new(detected_interfaces);
+        self.server_address_presets = suggestion_text_input::State::with_selection(
+            detected_interfaces,
+            Some(&song_data_provider.traktor_provider.address.clone()),
+        );
     }
 }
 

--- a/src/ui/config_window/bottombar.rs
+++ b/src/ui/config_window/bottombar.rs
@@ -7,7 +7,7 @@ use iced::widget::{Button, Column, button, column as col, container, row, scroll
 use iced::{Animation, Element, Font, Length, Theme, animation, font};
 use std::time::Duration;
 
-pub struct BottomBar {
+pub struct Bottombar {
     pub state: Animation<bool>,
 }
 
@@ -16,7 +16,7 @@ pub enum BottomBarMessage {
     Toggle,
 }
 
-impl BottomBar {
+impl Bottombar {
     pub fn new() -> Self {
         Self {
             state: Animation::new(false)
@@ -41,21 +41,22 @@ impl BottomBar {
         )
         .padding([0, 4]);
 
-        let statics_scrollable = scrollable(row(statics_buttons).spacing(5))
-            .direction(Direction::Horizontal(Scrollbar::new()))
-            .spacing(5)
-            .width(Length::Fill);
-
-        let statics_bar = container(statics_scrollable)
-            .width(Length::Fill)
-            .style(|t: &Theme| {
-                container::Style::default()
-                    .background(t.extended_palette().background.weakest.color)
-            });
-
         if self.state.value() {
             col![btn_bottombar_extend]
         } else {
+            let statics_scrollable = scrollable(row(statics_buttons).spacing(5))
+                .direction(Direction::Horizontal(Scrollbar::new()))
+                .spacing(5)
+                .width(Length::Fill);
+
+            let statics_bar =
+                container(statics_scrollable)
+                    .width(Length::Fill)
+                    .style(|t: &Theme| {
+                        container::Style::default()
+                            .background(t.extended_palette().background.weakest.color)
+                    });
+
             col![btn_bottombar_extend, statics_bar]
                 .align_x(Horizontal::Left)
                 .spacing(5)

--- a/src/ui/config_window/bottombar.rs
+++ b/src/ui/config_window/bottombar.rs
@@ -1,0 +1,100 @@
+use crate::dataloading::dataprovider::song_data_provider::SongChange;
+use crate::ui::config_window::material_icon_sized_message_button;
+use crate::{DanceInterpreter, Message};
+use iced::alignment::{Horizontal, Vertical};
+use iced::widget::scrollable::{Direction, Scrollbar};
+use iced::widget::{Button, Column, button, column as col, container, row, scrollable, text};
+use iced::{Animation, Element, Font, Length, Theme, animation, font};
+use std::time::Duration;
+
+pub struct BottomBar {
+    pub state: Animation<bool>,
+}
+
+#[derive(Debug, Clone)]
+pub enum BottomBarMessage {
+    Toggle,
+}
+
+impl BottomBar {
+    pub fn new() -> Self {
+        Self {
+            state: Animation::new(false)
+                .duration(Duration::from_millis(100))
+                .easing(animation::Easing::EaseInOut),
+        }
+    }
+
+    pub(crate) fn build<'a>(
+        &'a self,
+        dance_interpreter: &'a DanceInterpreter,
+    ) -> Column<'a, Message> {
+        let statics_buttons = self.get_statics_buttons(dance_interpreter);
+        let btn_bottombar_extend = material_icon_sized_message_button(
+            if self.state.value() {
+                "bottom_panel_close"
+            } else {
+                "bottom_panel_open"
+            },
+            20.0,
+            Message::Bottombar(BottomBarMessage::Toggle),
+        )
+        .padding([0, 4]);
+
+        let statics_scrollable = scrollable(row(statics_buttons).spacing(5))
+            .direction(Direction::Horizontal(Scrollbar::new()))
+            .spacing(5)
+            .width(Length::Fill);
+
+        let statics_bar = container(statics_scrollable)
+            .width(Length::Fill)
+            .style(|t: &Theme| {
+                container::Style::default()
+                    .background(t.extended_palette().background.weakest.color)
+            });
+
+        if self.state.value() {
+            col![btn_bottombar_extend]
+        } else {
+            col![btn_bottombar_extend, statics_bar]
+                .align_x(Horizontal::Left)
+                .spacing(5)
+        }
+    }
+
+    pub(crate) fn get_statics_buttons<'a>(
+        &self,
+        dance_interpreter: &'a DanceInterpreter,
+    ) -> Vec<Element<'a, Message>> {
+        let bold_font = Font {
+            family: font::Family::SansSerif,
+            weight: font::Weight::Bold,
+            stretch: font::Stretch::Normal,
+            style: font::Style::Normal,
+        };
+
+        let btn_blank: Button<Message> =
+            button(text("Blank").align_y(Vertical::Center).font(bold_font))
+                .style(button::secondary)
+                .on_press(Message::SongChanged(SongChange::Blank));
+        let btn_traktor: Button<Message> =
+            button(text("Traktor").align_y(Vertical::Center).font(bold_font))
+                .style(button::secondary)
+                .on_press(Message::SongChanged(SongChange::Traktor));
+        let mut statics: Vec<Element<_>> = dance_interpreter
+            .data_provider
+            .statics
+            .iter()
+            .enumerate()
+            .map(|(idx, s)| {
+                button(text(&s.dance).font(bold_font))
+                    .style(button::secondary)
+                    .on_press(Message::SongChanged(SongChange::StaticAbsolute(idx)))
+                    .into()
+            })
+            .collect();
+        statics.insert(0, btn_blank.into());
+        statics.insert(1, btn_traktor.into());
+        statics
+    }
+}

--- a/src/ui/config_window/bottombar.rs
+++ b/src/ui/config_window/bottombar.rs
@@ -51,7 +51,7 @@ impl Bottombar {
 
             let statics_bar =
                 container(statics_scrollable)
-                    .width(Length::Fill)
+                    .width(Length::Shrink)
                     .style(|t: &Theme| {
                         container::Style::default()
                             .background(t.extended_palette().background.weakest.color)

--- a/src/ui/config_window/bottombar.rs
+++ b/src/ui/config_window/bottombar.rs
@@ -1,9 +1,8 @@
 use crate::dataloading::dataprovider::song_data_provider::SongChange;
-use crate::ui::config_window::material_icon_sized_message_button;
 use crate::{DanceInterpreter, Message};
 use iced::alignment::{Horizontal, Vertical};
 use iced::widget::scrollable::{Direction, Scrollbar};
-use iced::widget::{Button, Column, button, column as col, container, row, scrollable, text};
+use iced::widget::{Button, Container, button, container, row, scrollable, text};
 use iced::{Animation, Element, Font, Length, Theme, animation, font};
 use std::time::Duration;
 
@@ -28,39 +27,21 @@ impl Bottombar {
     pub(crate) fn build<'a>(
         &'a self,
         dance_interpreter: &'a DanceInterpreter,
-    ) -> Column<'a, Message> {
+    ) -> Container<'a, Message> {
         let statics_buttons = self.get_statics_buttons(dance_interpreter);
-        let btn_bottombar_extend = material_icon_sized_message_button(
-            if self.state.value() {
-                "bottom_panel_close"
-            } else {
-                "bottom_panel_open"
-            },
-            20.0,
-            Message::Bottombar(BottomBarMessage::Toggle),
-        )
-        .padding([0, 4]);
+        let statics_scrollable = scrollable(row(statics_buttons).spacing(5))
+            .direction(Direction::Horizontal(Scrollbar::new()))
+            .spacing(5)
+            .width(Length::Fill);
 
-        if self.state.value() {
-            col![btn_bottombar_extend]
-        } else {
-            let statics_scrollable = scrollable(row(statics_buttons).spacing(5))
-                .direction(Direction::Horizontal(Scrollbar::new()))
-                .spacing(5)
-                .width(Length::Fill);
+        let statics_bar = container(statics_scrollable)
+            .width(Length::Shrink)
+            .style(|t: &Theme| {
+                container::Style::default()
+                    .background(t.extended_palette().background.weakest.color)
+            });
 
-            let statics_bar =
-                container(statics_scrollable)
-                    .width(Length::Shrink)
-                    .style(|t: &Theme| {
-                        container::Style::default()
-                            .background(t.extended_palette().background.weakest.color)
-                    });
-
-            col![btn_bottombar_extend, statics_bar]
-                .align_x(Horizontal::Left)
-                .spacing(5)
-        }
+        statics_bar.align_x(Horizontal::Left)
     }
 
     pub(crate) fn get_statics_buttons<'a>(

--- a/src/ui/config_window/mod.rs
+++ b/src/ui/config_window/mod.rs
@@ -91,41 +91,6 @@ impl ConfigWindow {
             .into()
     }
 
-    fn get_play_state(
-        &self,
-        dance_interpreter: &DanceInterpreter,
-        playlist_index: usize,
-    ) -> (bool, bool, bool, bool) {
-        let mut is_current = false;
-        let mut is_next = false;
-        let mut is_traktor = false;
-        let is_played = dance_interpreter
-            .data_provider
-            .playlist_played
-            .get(playlist_index)
-            .copied()
-            .unwrap_or(false);
-
-        if let SongDataSource::Playlist(i) = dance_interpreter.data_provider.current {
-            is_current = playlist_index == i;
-            is_next = playlist_index == (i + 1);
-        }
-
-        if let Some(SongDataSource::Playlist(i)) = dance_interpreter.data_provider.next {
-            is_next = playlist_index == i;
-        }
-
-        if matches!(
-            dance_interpreter.data_provider.current,
-            SongDataSource::Traktor
-        ) && let Some(index) = dance_interpreter.data_provider.get_current_traktor_index()
-        {
-            is_traktor = playlist_index == index;
-        }
-
-        (is_current, is_next, is_traktor, is_played)
-    }
-
     fn build_playlist_view(&'_ self, dance_interpreter: &DanceInterpreter) -> Column<'_, Message> {
         let trow: Row<_> = row![
             text!("#").width(Length::Fixed(24.0)),
@@ -148,7 +113,7 @@ impl ConfigWindow {
             .enumerate()
         {
             let (is_current, is_next, is_traktor, is_played) =
-                self.get_play_state(dance_interpreter, i);
+                dance_interpreter.data_provider.get_play_state(i);
             let icon: Element<Message> = if is_traktor {
                 material_icon("agriculture")
                     .width(Length::Fixed(24.0))

--- a/src/ui/config_window/mod.rs
+++ b/src/ui/config_window/mod.rs
@@ -1,56 +1,37 @@
+pub mod bottombar;
+pub mod sidebar;
+
 use crate::dataloading::dataprovider::song_data_provider::{
-    SongChange, SongDataEdit, SongDataProvider, SongDataSource,
+    SongChange, SongDataEdit, SongDataSource,
 };
-use crate::traktor_api::{TRAKTOR_SERVER_DEFAULT_ADDR, TraktorNextMode, TraktorSyncMode};
-use crate::ui::widget::canvas_toggle::CanvasToggle;
+use crate::ui::config_window::bottombar::BottomBar;
+use crate::ui::config_window::sidebar::Sidebar;
 use crate::ui::widget::dynamic_text_input::DynamicTextInput;
-use crate::ui::widget::suggestion_text_input::SuggestionTextInput;
-use crate::ui::widget::{power_button, suggestion_text_input};
 use crate::ui::{material_icon, material_icon_sized};
 use crate::{DanceInterpreter, Message, Window};
 use iced::advanced::Widget;
 use iced::alignment::Vertical;
 use iced::border::Radius;
-use iced::widget::scrollable::{Direction, RelativeOffset, Scrollbar};
-use iced::widget::space::horizontal;
+use iced::widget::scrollable::RelativeOffset;
 use iced::widget::{
-    Button, Column, Container, Row, Scrollable, Space, button, canvas, checkbox, column as col,
-    container, pick_list, radio, row, scrollable, text,
+    Button, Column, Row, Scrollable, Space, button, checkbox, column as col, radio, row,
+    scrollable, text,
 };
-use iced::{
-    Alignment, Animation, Border, Color, Element, Font, Length, Pixels, Renderer, Size, Theme,
-    animation, font, window,
-};
+use iced::{Alignment, Border, Color, Element, Length, Pixels, Renderer, Size, Theme, window};
 use iced_aw::style::{Status, menu_bar::primary};
 use iced_aw::widget::InnerBounds;
 use iced_aw::{Menu, MenuBar, iced_aw_font, menu, menu_bar, menu_items, quad};
-use network_interface::Addr::V4;
-use network_interface::{NetworkInterface, NetworkInterfaceConfig};
 use std::sync::LazyLock;
-use std::time::{Duration, Instant};
+use std::time::Instant;
 
 pub struct ConfigWindow {
     pub id: window::Id,
     pub closed: bool,
     pub size: Size,
     pub enable_autoscroll: bool,
-    pub sidebar_state: Animation<bool>,
-    pub bottombar_state: Animation<bool>,
-    pub server_address_text: String,
+    pub sidebar: Sidebar,
+    pub bottombar: BottomBar,
     pub theme: Theme,
-    pub power_button_cache: canvas::Cache,
-    server_address_presets: suggestion_text_input::State<String>,
-}
-
-#[derive(Debug, Clone)]
-pub enum SidebarMessage {
-    Toggle,
-    UpdateAddressPresets,
-}
-
-#[derive(Debug, Clone)]
-pub enum BottomBarMessage {
-    Toggle,
 }
 
 pub static PLAYLIST_SCROLLABLE_ID: LazyLock<iced::widget::Id> =
@@ -64,16 +45,9 @@ impl Window for ConfigWindow {
             size: Size::default(),
 
             enable_autoscroll: true,
-            sidebar_state: Animation::new(false)
-                .duration(Duration::from_millis(100))
-                .easing(animation::Easing::EaseInOut),
-            bottombar_state: Animation::new(false)
-                .duration(Duration::from_millis(100))
-                .easing(animation::Easing::EaseInOut),
-            server_address_presets: suggestion_text_input::State::default(),
-            server_address_text: String::new(),
+            sidebar: Sidebar::new(),
+            bottombar: BottomBar::new(),
             theme: Theme::Dark,
-            power_button_cache: canvas::Cache::default(),
         }
     }
 
@@ -92,20 +66,25 @@ impl Window for ConfigWindow {
 
 impl ConfigWindow {
     pub fn view<'a>(&'a self, dance_interpreter: &'a DanceInterpreter) -> Element<'a, Message> {
-        let top_bar = self.build_top_bar(dance_interpreter);
+        let top_bar = self.build_menu_bar(dance_interpreter);
         let playlist_view = self.build_playlist_view(dance_interpreter);
 
-        let side_bar =
-            self.build_server_sidebar(dance_interpreter)
-                .width(self.sidebar_state.interpolate(
-                    0.0,
-                    (self.size.width / 5.0).min(400.0),
+        let side_bar = self
+            .sidebar
+            .build(dance_interpreter)
+            .width(self.sidebar.state.interpolate(
+                30.0,
+                (self.size.width / 5.0).min(400.0),
+                Instant::now(),
+            ));
+        let bottom_bar =
+            self.bottombar
+                .build(dance_interpreter)
+                .height(self.bottombar.state.interpolate(
+                    80.0,
+                    self.size.height / 3.0,
                     Instant::now(),
                 ));
-        let bottom_bar = self.build_statics_bottombar(dance_interpreter).height(
-            self.bottombar_state
-                .interpolate(60.0, self.size.height / 3.0, Instant::now()),
-        );
 
         col![row![col![top_bar, playlist_view], side_bar], bottom_bar]
             .spacing(5)
@@ -145,112 +124,6 @@ impl ConfigWindow {
         }
 
         (is_current, is_next, is_traktor, is_played)
-    }
-
-    fn build_statics_bottombar<'a>(
-        &'a self,
-        dance_interpreter: &'a DanceInterpreter,
-    ) -> Container<'a, Message> {
-        container(self.build_statics_view(dance_interpreter))
-            .width(Length::Fill)
-            .style(|t: &Theme| {
-                container::Style::default()
-                    .background(t.extended_palette().background.weakest.color)
-            })
-    }
-
-    fn build_server_sidebar<'a>(
-        &'a self,
-        dance_interpreter: &'a DanceInterpreter,
-    ) -> Container<'a, Message> {
-        let sync_options = vec![
-            TraktorSyncMode::None,
-            TraktorSyncMode::Relative,
-            TraktorSyncMode::AbsoluteByNumber,
-            TraktorSyncMode::AbsoluteByName,
-        ];
-
-        let next_options = vec![
-            TraktorNextMode::None,
-            TraktorNextMode::DeckByPosition,
-            TraktorNextMode::DeckByNumber,
-            TraktorNextMode::PlaylistByNumber,
-            TraktorNextMode::PlaylistByName,
-        ];
-
-        container(
-            col![
-                text("Server Settings").size(24),
-                col![
-                    CanvasToggle::new(
-                        dance_interpreter.data_provider.traktor_provider.is_enabled,
-                        &self.power_button_cache
-                    )
-                    .on_toggle(Message::TraktorEnableServer)
-                    .on_draw(power_button::draw_power_button),
-                    text("Enable Server")
-                ],
-                col![
-                    text("Server Address: "),
-                    self.build_network_interface_combo_box(dance_interpreter)
-                ],
-                labeled_message_checkbox(
-                    "Enable Debug Logging",
-                    dance_interpreter
-                        .data_provider
-                        .traktor_provider
-                        .debug_logging,
-                    Message::TraktorEnableDebugLogging,
-                ),
-                label_message_button_fill_opt(
-                    "Reset Connection",
-                    dance_interpreter
-                        .data_provider
-                        .traktor_provider
-                        .is_enabled
-                        .then_some(Message::TraktorReconnect)
-                ),
-                col![
-                    text("Sync Mode"),
-                    pick_list(
-                        sync_options.clone(),
-                        Some(dance_interpreter.data_provider.traktor_provider.sync_mode),
-                        Message::TraktorSetSyncMode
-                    )
-                ]
-                .align_x(Alignment::Center),
-                col![
-                    text("Next Song Mode"),
-                    pick_list(
-                        next_options.clone(),
-                        Some(dance_interpreter.data_provider.traktor_provider.next_mode),
-                        Message::TraktorSetNextMode
-                    )
-                ]
-                .align_x(Alignment::Center),
-                col![
-                    text("Next Song Mode (Fallback)"),
-                    pick_list(
-                        next_options.clone(),
-                        Some(
-                            dance_interpreter
-                                .data_provider
-                                .traktor_provider
-                                .next_mode_fallback
-                        ),
-                        Message::TraktorSetNextModeFallback
-                    )
-                ]
-                .align_x(Alignment::Center)
-            ]
-            .align_x(Alignment::Center)
-            .spacing(10)
-            .padding(10),
-        )
-        .height(Length::Fill)
-        .style(|t| {
-            container::Style::default().background(t.extended_palette().background.weakest.color)
-        })
     }
 
     fn build_playlist_view(&'_ self, dance_interpreter: &DanceInterpreter) -> Column<'_, Message> {
@@ -342,73 +215,6 @@ impl ConfigWindow {
         col!(trow, playlist_scrollable).spacing(5)
     }
 
-    fn build_statics_view<'a>(
-        &self,
-        dance_interpreter: &'a DanceInterpreter,
-    ) -> Scrollable<'a, Message> {
-        let bold_font = Font {
-            family: font::Family::SansSerif,
-            weight: font::Weight::Bold,
-            stretch: font::Stretch::Normal,
-            style: font::Style::Normal,
-        };
-
-        let btn_bottombar_extend = material_icon_sized_message_button(
-            if self.sidebar_state.value() {
-                "bottom_panel_close"
-            } else {
-                "bottom_panel_open"
-            },
-            20.0,
-            Message::Bottombar(BottomBarMessage::Toggle),
-        );
-        let btn_blank: Button<Message> =
-            button(text("Blank").align_y(Vertical::Center).font(bold_font))
-                .style(button::secondary)
-                .on_press(Message::SongChanged(SongChange::Blank));
-        let btn_traktor: Button<Message> =
-            button(text("Traktor").align_y(Vertical::Center).font(bold_font))
-                .style(button::secondary)
-                .on_press(Message::SongChanged(SongChange::Traktor));
-        let mut statics: Vec<Element<_>> = dance_interpreter
-            .data_provider
-            .statics
-            .iter()
-            .enumerate()
-            .map(|(idx, s)| {
-                button(text(&s.dance).font(bold_font))
-                    .style(button::secondary)
-                    .on_press(Message::SongChanged(SongChange::StaticAbsolute(idx)))
-                    .into()
-            })
-            .collect();
-        statics.insert(0, btn_bottombar_extend.into());
-        statics.insert(1, btn_blank.into());
-        statics.insert(2, btn_traktor.into());
-
-        scrollable(row(statics).spacing(5))
-            .direction(Direction::Horizontal(Scrollbar::new()))
-            .spacing(5)
-            .width(Length::Fill)
-    }
-
-    fn build_top_bar<'a>(&self, dance_interpreter: &'a DanceInterpreter) -> Row<'a, Message> {
-        row![
-            self.build_menu_bar(dance_interpreter),
-            horizontal(),
-            material_icon_sized_message_button(
-                if self.sidebar_state.value() {
-                    "right_panel_close"
-                } else {
-                    "right_panel_open"
-                },
-                20.0,
-                Message::Sidebar(SidebarMessage::Toggle)
-            )
-            .padding([0, 4])
-        ]
-    }
-
     fn build_menu_bar<'a>(
         &self,
         dance_interpreter: &'a DanceInterpreter,
@@ -462,76 +268,6 @@ impl ConfigWindow {
 
         mb
     }
-
-    fn build_network_interface_combo_box(
-        &'_ self,
-        dance_interpreter: &DanceInterpreter,
-    ) -> SuggestionTextInput<'_, String, Message> {
-        SuggestionTextInput::new(
-            &self.server_address_presets,
-            if !self.server_address_text.is_empty() {
-                self.server_address_text.as_ref()
-            } else {
-                TRAKTOR_SERVER_DEFAULT_ADDR
-            },
-            Some(&dance_interpreter.data_provider.traktor_provider.address),
-            Message::TraktorChangeAndSubmitAddress,
-        )
-        .on_open(Message::Sidebar(SidebarMessage::UpdateAddressPresets))
-        .on_option_hovered(Message::TraktorChangeAddress)
-        .on_input(Message::TraktorChangeAddress)
-        .on_close(Message::TraktorSubmitAddress)
-    }
-
-    pub fn update_network_interface_selection(&mut self, song_data_provider: &SongDataProvider) {
-        let mut detected_interfaces: Vec<String> =
-            get_formatted_network_interfaces(song_data_provider)
-                .into_iter()
-                .map(|(_, _, formatted)| formatted)
-                .collect();
-        detected_interfaces.push(TRAKTOR_SERVER_DEFAULT_ADDR.to_owned());
-        detected_interfaces.sort();
-
-        self.server_address_presets = suggestion_text_input::State::with_selection(
-            detected_interfaces,
-            Some(&song_data_provider.traktor_provider.address.clone()),
-        );
-    }
-}
-
-fn get_network_interfaces() -> Vec<(String, String)> {
-    let mut interfaces = vec![("any".to_owned(), "0.0.0.0".to_owned())];
-
-    if let Ok(network_interfaces) = NetworkInterface::show() {
-        for i in network_interfaces {
-            for addr in i.addr {
-                let V4(ipv4_addr) = addr else {
-                    continue;
-                };
-
-                interfaces.push((i.name.clone(), ipv4_addr.ip.to_string()));
-            }
-        }
-    }
-
-    interfaces
-}
-
-fn get_formatted_network_interfaces(
-    song_data_provider: &'_ SongDataProvider,
-) -> Vec<(String, String, String)> {
-    let interfaces = get_network_interfaces();
-
-    let original_addr = song_data_provider
-        .traktor_provider
-        .get_socket_addr()
-        .unwrap_or(TRAKTOR_SERVER_DEFAULT_ADDR.parse().unwrap());
-    let original_port = original_addr.port();
-
-    interfaces
-        .into_iter()
-        .map(|(name, addr)| (name, addr.clone(), format!("{}:{}", addr, original_port)))
-        .collect()
 }
 
 fn label_message_button_fill<'a>(

--- a/src/ui/config_window/mod.rs
+++ b/src/ui/config_window/mod.rs
@@ -4,7 +4,7 @@ pub mod sidebar;
 use crate::dataloading::dataprovider::song_data_provider::{
     SongChange, SongDataEdit, SongDataSource,
 };
-use crate::ui::config_window::bottombar::BottomBar;
+use crate::ui::config_window::bottombar::Bottombar;
 use crate::ui::config_window::sidebar::Sidebar;
 use crate::ui::widget::dynamic_text_input::DynamicTextInput;
 use crate::ui::{material_icon, material_icon_sized};
@@ -30,7 +30,7 @@ pub struct ConfigWindow {
     pub size: Size,
     pub enable_autoscroll: bool,
     pub sidebar: Sidebar,
-    pub bottombar: BottomBar,
+    pub bottombar: Bottombar,
     pub theme: Theme,
 }
 
@@ -46,7 +46,7 @@ impl Window for ConfigWindow {
 
             enable_autoscroll: true,
             sidebar: Sidebar::new(),
-            bottombar: BottomBar::new(),
+            bottombar: Bottombar::new(),
             theme: Theme::Dark,
         }
     }

--- a/src/ui/config_window/mod.rs
+++ b/src/ui/config_window/mod.rs
@@ -77,14 +77,10 @@ impl ConfigWindow {
                 (self.size.width / 5.0).min(400.0),
                 Instant::now(),
             ));
-        let bottom_bar =
-            self.bottombar
-                .build(dance_interpreter)
-                .height(self.bottombar.state.interpolate(
-                    80.0,
-                    self.size.height / 3.0,
-                    Instant::now(),
-                ));
+        let bottom_bar = self
+            .bottombar
+            .build(dance_interpreter)
+            .height(Length::Shrink);
 
         col![row![col![top_bar, playlist_view], side_bar], bottom_bar]
             .spacing(5)

--- a/src/ui/config_window/mod.rs
+++ b/src/ui/config_window/mod.rs
@@ -276,6 +276,7 @@ fn submenu_button(label: &'_ str) -> Button<'_, Message, Theme, Renderer> {
     .width(Length::Fill)
 }
 
+#[allow(dead_code)]
 fn label_message_button_opt(label: &'_ str, message: Option<Message>) -> Button<'_, Message> {
     if let Some(message) = message {
         label_message_button(label, message)
@@ -284,10 +285,6 @@ fn label_message_button_opt(label: &'_ str, message: Option<Message>) -> Button<
             .padding([4, 8])
             .style(button::secondary)
     }
-}
-
-fn label_message_button_fill_opt(label: &'_ str, message: Option<Message>) -> Button<'_, Message> {
-    label_message_button_opt(label, message).width(Length::Fill)
 }
 
 fn material_icon_message_button(icon_id: &'_ str, message: Message) -> Button<'_, Message> {

--- a/src/ui/config_window/sidebar.rs
+++ b/src/ui/config_window/sidebar.rs
@@ -80,7 +80,8 @@ impl Sidebar {
                             .on_toggle(Message::TraktorEnableServer)
                             .on_draw(power_button::draw),
                             text("Enable Server")
-                        ],
+                        ]
+                        .align_x(Alignment::Center),
                         col![
                             CanvasToggle::new(
                                 dance_interpreter.data_provider.traktor_provider.is_enabled,
@@ -90,6 +91,7 @@ impl Sidebar {
                             .on_draw(restart_button::draw),
                             text("Restart Server")
                         ]
+                        .align_x(Alignment::Center)
                     ]
                     .spacing(10),
                     col![

--- a/src/ui/config_window/sidebar.rs
+++ b/src/ui/config_window/sidebar.rs
@@ -1,0 +1,217 @@
+use crate::dataloading::dataprovider::song_data_provider::SongDataProvider;
+use crate::traktor_api::{TRAKTOR_SERVER_DEFAULT_ADDR, TraktorNextMode, TraktorSyncMode};
+use crate::ui::config_window::{
+    label_message_button_fill_opt, labeled_message_checkbox, material_icon_sized_message_button,
+};
+use crate::ui::widget::canvas_toggle::CanvasToggle;
+use crate::ui::widget::suggestion_text_input::SuggestionTextInput;
+use crate::ui::widget::{power_button, suggestion_text_input};
+use crate::{DanceInterpreter, Message};
+use iced::alignment::Vertical;
+use iced::widget::{Row, canvas, column as col, container, pick_list, row, text};
+use iced::{Alignment, Animation, Length, animation};
+use network_interface::Addr::V4;
+use network_interface::{NetworkInterface, NetworkInterfaceConfig};
+use std::time::Duration;
+
+pub struct Sidebar {
+    pub state: Animation<bool>,
+    pub power_button_cache: canvas::Cache,
+    server_address_presets: suggestion_text_input::State<String>,
+    pub server_address_text: String,
+}
+
+#[derive(Debug, Clone)]
+pub enum SidebarMessage {
+    Toggle,
+    UpdateAddressPresets,
+}
+
+impl Sidebar {
+    pub fn new() -> Self {
+        Self {
+            state: Animation::new(false)
+                .duration(Duration::from_millis(100))
+                .easing(animation::Easing::EaseInOut),
+            power_button_cache: canvas::Cache::default(),
+            server_address_presets: suggestion_text_input::State::default(),
+            server_address_text: String::new(),
+        }
+    }
+
+    pub(crate) fn build<'a>(&'a self, dance_interpreter: &'a DanceInterpreter) -> Row<'a, Message> {
+        let sync_options = vec![
+            TraktorSyncMode::None,
+            TraktorSyncMode::Relative,
+            TraktorSyncMode::AbsoluteByNumber,
+            TraktorSyncMode::AbsoluteByName,
+        ];
+
+        let next_options = vec![
+            TraktorNextMode::None,
+            TraktorNextMode::DeckByPosition,
+            TraktorNextMode::DeckByNumber,
+            TraktorNextMode::PlaylistByNumber,
+            TraktorNextMode::PlaylistByName,
+        ];
+
+        row![
+            material_icon_sized_message_button(
+                if self.state.value() {
+                    "right_panel_close"
+                } else {
+                    "right_panel_open"
+                },
+                20.0,
+                Message::Sidebar(SidebarMessage::Toggle)
+            )
+            .padding([0, 4]),
+            container(
+                col![
+                    text("Server Settings").size(24),
+                    col![
+                        CanvasToggle::new(
+                            dance_interpreter.data_provider.traktor_provider.is_enabled,
+                            &self.power_button_cache
+                        )
+                        .on_toggle(Message::TraktorEnableServer)
+                        .on_draw(power_button::draw_power_button),
+                        text("Enable Server")
+                    ],
+                    col![
+                        text("Server Address: "),
+                        self.build_network_interface_combo_box(dance_interpreter)
+                    ],
+                    labeled_message_checkbox(
+                        "Enable Debug Logging",
+                        dance_interpreter
+                            .data_provider
+                            .traktor_provider
+                            .debug_logging,
+                        Message::TraktorEnableDebugLogging,
+                    ),
+                    label_message_button_fill_opt(
+                        "Reset Connection",
+                        dance_interpreter
+                            .data_provider
+                            .traktor_provider
+                            .is_enabled
+                            .then_some(Message::TraktorReconnect)
+                    ),
+                    col![
+                        text("Sync Mode"),
+                        pick_list(
+                            sync_options.clone(),
+                            Some(dance_interpreter.data_provider.traktor_provider.sync_mode),
+                            Message::TraktorSetSyncMode
+                        )
+                    ]
+                    .align_x(Alignment::Center),
+                    col![
+                        text("Next Song Mode"),
+                        pick_list(
+                            next_options.clone(),
+                            Some(dance_interpreter.data_provider.traktor_provider.next_mode),
+                            Message::TraktorSetNextMode
+                        )
+                    ]
+                    .align_x(Alignment::Center),
+                    col![
+                        text("Next Song Mode (Fallback)"),
+                        pick_list(
+                            next_options.clone(),
+                            Some(
+                                dance_interpreter
+                                    .data_provider
+                                    .traktor_provider
+                                    .next_mode_fallback
+                            ),
+                            Message::TraktorSetNextModeFallback
+                        )
+                    ]
+                    .align_x(Alignment::Center)
+                ]
+                .align_x(Alignment::Center)
+                .spacing(10)
+                .padding(10),
+            )
+            .height(Length::Fill)
+            .style(|t| {
+                container::Style::default()
+                    .background(t.extended_palette().background.weakest.color)
+            })
+        ]
+        .spacing(5)
+        .align_y(Vertical::Top)
+    }
+
+    fn build_network_interface_combo_box(
+        &'_ self,
+        dance_interpreter: &DanceInterpreter,
+    ) -> SuggestionTextInput<'_, String, Message> {
+        SuggestionTextInput::new(
+            &self.server_address_presets,
+            if !self.server_address_text.is_empty() {
+                self.server_address_text.as_ref()
+            } else {
+                TRAKTOR_SERVER_DEFAULT_ADDR
+            },
+            Some(&dance_interpreter.data_provider.traktor_provider.address),
+            Message::TraktorChangeAndSubmitAddress,
+        )
+        .on_open(Message::Sidebar(SidebarMessage::UpdateAddressPresets))
+        .on_option_hovered(Message::TraktorChangeAddress)
+        .on_input(Message::TraktorChangeAddress)
+        .on_close(Message::TraktorSubmitAddress)
+    }
+
+    pub fn update_network_interface_selection(&mut self, song_data_provider: &SongDataProvider) {
+        let mut detected_interfaces: Vec<String> =
+            get_formatted_network_interfaces(song_data_provider)
+                .into_iter()
+                .map(|(_, _, formatted)| formatted)
+                .collect();
+        detected_interfaces.push(TRAKTOR_SERVER_DEFAULT_ADDR.to_owned());
+        detected_interfaces.sort();
+
+        self.server_address_presets = suggestion_text_input::State::with_selection(
+            detected_interfaces,
+            Some(&song_data_provider.traktor_provider.address.clone()),
+        );
+    }
+}
+
+fn get_network_interfaces() -> Vec<(String, String)> {
+    let mut interfaces = vec![("any".to_owned(), "0.0.0.0".to_owned())];
+
+    if let Ok(network_interfaces) = NetworkInterface::show() {
+        for i in network_interfaces {
+            for addr in i.addr {
+                let V4(ipv4_addr) = addr else {
+                    continue;
+                };
+
+                interfaces.push((i.name.clone(), ipv4_addr.ip.to_string()));
+            }
+        }
+    }
+
+    interfaces
+}
+
+fn get_formatted_network_interfaces(
+    song_data_provider: &'_ SongDataProvider,
+) -> Vec<(String, String, String)> {
+    let interfaces = get_network_interfaces();
+
+    let original_addr = song_data_provider
+        .traktor_provider
+        .get_socket_addr()
+        .unwrap_or(TRAKTOR_SERVER_DEFAULT_ADDR.parse().unwrap());
+    let original_port = original_addr.port();
+
+    interfaces
+        .into_iter()
+        .map(|(name, addr)| (name, addr.clone(), format!("{}:{}", addr, original_port)))
+        .collect()
+}

--- a/src/ui/config_window/sidebar.rs
+++ b/src/ui/config_window/sidebar.rs
@@ -5,7 +5,7 @@ use crate::ui::config_window::{
 };
 use crate::ui::widget::canvas_toggle::CanvasToggle;
 use crate::ui::widget::suggestion_text_input::SuggestionTextInput;
-use crate::ui::widget::{power_button, suggestion_text_input};
+use crate::ui::widget::{power_button, restart_button, suggestion_text_input};
 use crate::{DanceInterpreter, Message};
 use iced::alignment::Vertical;
 use iced::widget::{Row, canvas, column as col, container, pick_list, row, text};
@@ -17,6 +17,7 @@ use std::time::Duration;
 pub struct Sidebar {
     pub state: Animation<bool>,
     pub power_button_cache: canvas::Cache,
+    pub restart_button_cache: canvas::Cache,
     server_address_presets: suggestion_text_input::State<String>,
     pub server_address_text: String,
 }
@@ -34,6 +35,7 @@ impl Sidebar {
                 .duration(Duration::from_millis(100))
                 .easing(animation::Easing::EaseInOut),
             power_button_cache: canvas::Cache::default(),
+            restart_button_cache: canvas::Cache::default(),
             server_address_presets: suggestion_text_input::State::default(),
             server_address_text: String::new(),
         }
@@ -69,15 +71,27 @@ impl Sidebar {
             container(
                 col![
                     text("Server Settings").size(24),
-                    col![
-                        CanvasToggle::new(
-                            dance_interpreter.data_provider.traktor_provider.is_enabled,
-                            &self.power_button_cache
-                        )
-                        .on_toggle(Message::TraktorEnableServer)
-                        .on_draw(power_button::draw_power_button),
-                        text("Enable Server")
-                    ],
+                    row![
+                        col![
+                            CanvasToggle::new(
+                                dance_interpreter.data_provider.traktor_provider.is_enabled,
+                                &self.power_button_cache
+                            )
+                            .on_toggle(Message::TraktorEnableServer)
+                            .on_draw(power_button::draw),
+                            text("Enable Server")
+                        ],
+                        col![
+                            CanvasToggle::new(
+                                dance_interpreter.data_provider.traktor_provider.is_enabled,
+                                &self.restart_button_cache
+                            )
+                            .on_toggle(|_| Message::TraktorReconnect)
+                            .on_draw(restart_button::draw),
+                            text("Restart Server")
+                        ]
+                    ]
+                    .spacing(10),
                     col![
                         text("Server Address: "),
                         self.build_network_interface_combo_box(dance_interpreter)
@@ -141,7 +155,6 @@ impl Sidebar {
                     .background(t.extended_palette().background.weakest.color)
             })
         ]
-        .spacing(5)
         .align_y(Vertical::Top)
     }
 

--- a/src/ui/config_window/sidebar.rs
+++ b/src/ui/config_window/sidebar.rs
@@ -1,8 +1,6 @@
 use crate::dataloading::dataprovider::song_data_provider::SongDataProvider;
 use crate::traktor_api::{TRAKTOR_SERVER_DEFAULT_ADDR, TraktorNextMode, TraktorSyncMode};
-use crate::ui::config_window::{
-    label_message_button_fill_opt, labeled_message_checkbox, material_icon_sized_message_button,
-};
+use crate::ui::config_window::{labeled_message_checkbox, material_icon_sized_message_button};
 use crate::ui::widget::canvas_toggle::CanvasToggle;
 use crate::ui::widget::suggestion_text_input::SuggestionTextInput;
 use crate::ui::widget::{power_button, restart_button, suggestion_text_input};
@@ -106,14 +104,6 @@ impl Sidebar {
                             .debug_logging,
                         Message::TraktorEnableDebugLogging,
                     ),
-                    label_message_button_fill_opt(
-                        "Reset Connection",
-                        dance_interpreter
-                            .data_provider
-                            .traktor_provider
-                            .is_enabled
-                            .then_some(Message::TraktorReconnect)
-                    ),
                     col![
                         text("Sync Mode"),
                         pick_list(
@@ -121,6 +111,7 @@ impl Sidebar {
                             Some(dance_interpreter.data_provider.traktor_provider.sync_mode),
                             Message::TraktorSetSyncMode
                         )
+                        .width(Length::Fill)
                     ]
                     .align_x(Alignment::Center),
                     col![
@@ -130,6 +121,7 @@ impl Sidebar {
                             Some(dance_interpreter.data_provider.traktor_provider.next_mode),
                             Message::TraktorSetNextMode
                         )
+                        .width(Length::Fill)
                     ]
                     .align_x(Alignment::Center),
                     col![
@@ -144,6 +136,7 @@ impl Sidebar {
                             ),
                             Message::TraktorSetNextModeFallback
                         )
+                        .width(Length::Fill)
                     ]
                     .align_x(Alignment::Center)
                 ]

--- a/src/ui/config_window/sidebar.rs
+++ b/src/ui/config_window/sidebar.rs
@@ -184,7 +184,7 @@ impl Sidebar {
 
         self.server_address_presets = suggestion_text_input::State::with_selection(
             detected_interfaces,
-            Some(&song_data_provider.traktor_provider.address.clone()),
+            Some(&song_data_provider.traktor_provider.address),
         );
     }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,10 +1,18 @@
 use iced::widget::Text;
 use iced::widget::text::Shaping;
-use iced::{Font, Length, Renderer, Theme};
+use iced::{Font, Length, Pixels, Renderer, Theme};
 
 pub mod config_window;
 pub mod song_window;
 pub mod widget;
+
+pub fn material_icon_sized(id: &'_ str, size: impl Into<Pixels>) -> Text<'_, Theme, Renderer> {
+    Text::new(id)
+        .font(Font::with_name("Material Symbols Outlined"))
+        .size(size)
+        .shaping(Shaping::Advanced)
+        .width(Length::Shrink)
+}
 
 pub fn material_icon(id: &'_ str) -> Text<'_, Theme, Renderer> {
     Text::new(id)

--- a/src/ui/widget/canvas_toggle.rs
+++ b/src/ui/widget/canvas_toggle.rs
@@ -1,25 +1,34 @@
 use crate::Message;
 use iced::advanced::graphics::core::event::Event;
-use iced::widget::canvas::{Frame, Geometry};
+use iced::widget::canvas::{Cache, Frame, Geometry};
 use iced::widget::{Action, Canvas, canvas};
-use iced::{Element, Rectangle, Renderer, Theme, mouse};
+use iced::{Element, Length, Rectangle, Renderer, Theme, mouse};
+use std::rc::Rc;
 
-type DrawFunction<'a> = Box<dyn Fn(&Theme, &mut Frame, bool) + 'a>;
+type DrawFunction<'a> = Rc<dyn Fn(&Theme, &mut Frame, bool) + 'a>;
+type ToggleFunction<'a> = Rc<dyn Fn(bool) -> Message + 'a>;
 
+#[derive(Clone)]
 pub struct CanvasToggle<'a> {
     is_checked: bool,
-    on_toggle: Option<Box<dyn Fn(bool) -> Message + 'a>>,
+    on_toggle: Option<ToggleFunction<'a>>,
     on_draw: Option<DrawFunction<'a>>,
-    cache: &'a canvas::Cache,
+    cache: &'a Cache,
+    width: Length,
+    height: Length,
 }
 
 impl<'a> CanvasToggle<'a> {
-    pub fn new(is_checked: bool, cache: &'a canvas::Cache) -> Self {
+    const DEFAULT_SIZE: f32 = 75.0;
+
+    pub fn new(is_checked: bool, cache: &'a Cache) -> Self {
         Self {
             is_checked,
             on_toggle: None,
             on_draw: None,
             cache,
+            width: Length::Fixed(Self::DEFAULT_SIZE),
+            height: Length::Fixed(Self::DEFAULT_SIZE),
         }
     }
 
@@ -27,7 +36,7 @@ impl<'a> CanvasToggle<'a> {
     where
         F: 'a + Fn(bool) -> Message,
     {
-        self.on_toggle = Some(Box::new(f));
+        self.on_toggle = Some(Rc::new(f));
         self
     }
 
@@ -35,20 +44,31 @@ impl<'a> CanvasToggle<'a> {
     where
         F: 'a + Fn(&Theme, &mut Frame, bool) + 'a,
     {
-        self.on_draw = Some(Box::new(f));
+        self.on_draw = Some(Rc::new(f));
+        self
+    }
+
+    pub fn width(mut self, width: f32) -> Self {
+        self.width = Length::Fixed(width);
+        self
+    }
+    pub fn height(mut self, height: f32) -> Self {
+        self.height = Length::Fixed(height);
         self
     }
 }
 
 impl<'a> From<CanvasToggle<'a>> for Canvas<CanvasToggle<'a>, Message, Theme, Renderer> {
     fn from(value: CanvasToggle<'a>) -> Self {
-        Canvas::new(value)
+        let w = value.width;
+        let h = value.height;
+        Canvas::new(value).width(w).height(h)
     }
 }
 
 impl<'a> From<CanvasToggle<'a>> for Element<'a, Message, Theme, Renderer> {
     fn from(value: CanvasToggle<'a>) -> Self {
-        Canvas::new(value).into()
+        <CanvasToggle<'a> as Into<Canvas<CanvasToggle, Message>>>::into(value).into()
     }
 }
 

--- a/src/ui/widget/canvas_toggle.rs
+++ b/src/ui/widget/canvas_toggle.rs
@@ -1,0 +1,105 @@
+use crate::Message;
+use iced::advanced::graphics::core::event::Event;
+use iced::widget::canvas::{Frame, Geometry};
+use iced::widget::{Action, Canvas, canvas};
+use iced::{Element, Rectangle, Renderer, Theme, mouse};
+
+type DrawFunction<'a> = Box<dyn Fn(&Theme, &mut Frame, bool) + 'a>;
+
+pub struct CanvasToggle<'a> {
+    is_checked: bool,
+    on_toggle: Option<Box<dyn Fn(bool) -> Message + 'a>>,
+    on_draw: Option<DrawFunction<'a>>,
+    cache: &'a canvas::Cache,
+}
+
+impl<'a> CanvasToggle<'a> {
+    pub fn new(is_checked: bool, cache: &'a canvas::Cache) -> Self {
+        Self {
+            is_checked,
+            on_toggle: None,
+            on_draw: None,
+            cache,
+        }
+    }
+
+    pub fn on_toggle<F>(mut self, f: F) -> Self
+    where
+        F: 'a + Fn(bool) -> Message,
+    {
+        self.on_toggle = Some(Box::new(f));
+        self
+    }
+
+    pub fn on_draw<F>(mut self, f: F) -> Self
+    where
+        F: 'a + Fn(&Theme, &mut Frame, bool) + 'a,
+    {
+        self.on_draw = Some(Box::new(f));
+        self
+    }
+}
+
+impl<'a> From<CanvasToggle<'a>> for Canvas<CanvasToggle<'a>, Message, Theme, Renderer> {
+    fn from(value: CanvasToggle<'a>) -> Self {
+        Canvas::new(value)
+    }
+}
+
+impl<'a> From<CanvasToggle<'a>> for Element<'a, Message, Theme, Renderer> {
+    fn from(value: CanvasToggle<'a>) -> Self {
+        Canvas::new(value).into()
+    }
+}
+
+impl<'a> canvas::Program<Message> for CanvasToggle<'a> {
+    type State = ();
+
+    fn update(
+        &self,
+        _state: &mut (),
+        event: &Event,
+        bounds: Rectangle,
+        cursor: mouse::Cursor,
+    ) -> Option<Action<Message>> {
+        if let Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) = event
+            && cursor.is_over(bounds)
+            && let Some(on_toggle) = &self.on_toggle
+        {
+            Some(Action::publish(on_toggle(!self.is_checked)))
+        } else {
+            None
+        }
+    }
+
+    fn draw(
+        &self,
+        _state: &(),
+        renderer: &Renderer,
+        theme: &Theme,
+        bounds: Rectangle,
+        _cursor: mouse::Cursor,
+    ) -> Vec<Geometry<Renderer>> {
+        if let Some(on_draw) = &self.on_draw {
+            let geo = self.cache.draw(renderer, bounds.size(), |frame| {
+                on_draw(theme, frame, self.is_checked);
+            });
+            vec![geo]
+        } else {
+            Vec::new()
+        }
+    }
+
+    fn mouse_interaction(
+        &self,
+        _state: &(),
+        bounds: Rectangle,
+        cursor: mouse::Cursor,
+    ) -> mouse::Interaction {
+        if cursor.is_over(bounds) {
+            mouse::Interaction::Pointer
+        } else {
+            mouse::Interaction::default()
+        }
+    }
+}

--- a/src/ui/widget/canvas_toggle.rs
+++ b/src/ui/widget/canvas_toggle.rs
@@ -1,12 +1,18 @@
+// canvas_toggle.rs
+
 use crate::Message;
 use iced::advanced::graphics::core::event::Event;
-use iced::widget::canvas::{Cache, Frame, Geometry};
+use iced::mouse::Cursor;
+use iced::widget::canvas::{Cache, Frame, Geometry, Path};
 use iced::widget::{Action, Canvas, canvas};
-use iced::{Element, Length, Rectangle, Renderer, Theme, mouse};
+use iced::{Element, Length, Point, Rectangle, Renderer, Theme, mouse, window};
 use std::rc::Rc;
+use std::time::Instant;
 
-type DrawFunction<'a> = Rc<dyn Fn(&Theme, &mut Frame, bool) + 'a>;
+type DrawFunction<'a> = Rc<dyn Fn(&Theme, &mut Frame, Rectangle, Cursor, bool) + 'a>;
 type ToggleFunction<'a> = Rc<dyn Fn(bool) -> Message + 'a>;
+
+const ANIM_SECS: f32 = 0.28;
 
 #[derive(Clone)]
 pub struct CanvasToggle<'a> {
@@ -42,7 +48,7 @@ impl<'a> CanvasToggle<'a> {
 
     pub fn on_draw<F>(mut self, f: F) -> Self
     where
-        F: 'a + Fn(&Theme, &mut Frame, bool) + 'a,
+        F: 'a + Fn(&Theme, &mut Frame, Rectangle, Cursor, bool) + 'a,
     {
         self.on_draw = Some(Rc::new(f));
         self
@@ -52,6 +58,7 @@ impl<'a> CanvasToggle<'a> {
         self.width = Length::Fixed(width);
         self
     }
+
     pub fn height(mut self, height: f32) -> Self {
         self.height = Length::Fixed(height);
         self
@@ -73,46 +80,100 @@ impl<'a> From<CanvasToggle<'a>> for Element<'a, Message, Theme, Renderer> {
 }
 
 impl<'a> canvas::Program<Message> for CanvasToggle<'a> {
-    type State = ();
+    // State now holds the instant of the last click for the ripple animation.
+    type State = Option<Instant>;
 
     fn update(
         &self,
-        _state: &mut (),
+        state: &mut Self::State,
         event: &Event,
         bounds: Rectangle,
         cursor: mouse::Cursor,
     ) -> Option<Action<Message>> {
+        if let Some(started) = *state {
+            if started.elapsed().as_secs_f32() < ANIM_SECS {
+                // Mouse events and the redraw-requested window event both
+                // creates loop, until animation is finished
+                if matches!(
+                    event,
+                    Event::Mouse(_) | Event::Window(window::Event::RedrawRequested(_))
+                ) {
+                    return Some(Action::request_redraw());
+                }
+            } else {
+                *state = None;
+            }
+        }
+
         if let Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) = event
             && cursor.is_over(bounds)
             && let Some(on_toggle) = &self.on_toggle
         {
-            Some(Action::publish(on_toggle(!self.is_checked)))
-        } else {
-            None
+            *state = Some(Instant::now());
+            return Some(Action::publish(on_toggle(!self.is_checked)));
         }
+
+        None
     }
 
     fn draw(
         &self,
-        _state: &(),
+        state: &Self::State,
         renderer: &Renderer,
         theme: &Theme,
         bounds: Rectangle,
-        _cursor: mouse::Cursor,
+        cursor: mouse::Cursor,
     ) -> Vec<Geometry<Renderer>> {
-        if let Some(on_draw) = &self.on_draw {
+        let Some(on_draw) = &self.on_draw else {
+            return Vec::new();
+        };
+
+        // When there is no active animation we can use the shared cache so
+        // the canvas is only redrawn when the parent invalidates it.
+        if state.is_none() {
             let geo = self.cache.draw(renderer, bounds.size(), |frame| {
-                on_draw(theme, frame, self.is_checked);
+                on_draw(theme, frame, bounds, cursor, self.is_checked);
             });
-            vec![geo]
-        } else {
-            Vec::new()
+            return vec![geo];
         }
+
+        // --- animated frame: draw base + ripple overlay on a fresh Frame ---
+        let mut frame = Frame::new(renderer, bounds.size());
+        on_draw(theme, &mut frame, bounds, cursor, self.is_checked);
+
+        if let Some(started) = state {
+            let progress = (started.elapsed().as_secs_f32() / ANIM_SECS).clamp(0.0, 1.0);
+
+            let size = frame.size();
+            let cx = size.width / 2.0;
+            let cy = size.height / 2.0;
+            let dim = size.width.min(size.height);
+
+            // Ripple expands from 0 → bg_r and fades from 0.45 → 0
+            let max_r = dim * 0.46;
+            let r = max_r * progress;
+            let alpha = (1.0 - progress) * 0.45;
+
+            // Use the secondary colour so the ripple feels intentional
+            let mut ripple_color = theme.extended_palette().secondary.base.color;
+            ripple_color.a = alpha;
+
+            let ripple = Path::new(|b| b.circle(Point::new(cx, cy), r));
+            frame.fill(
+                &ripple,
+                canvas::Fill {
+                    style: canvas::Style::Solid(ripple_color),
+                    rule: canvas::fill::Rule::NonZero,
+                },
+            );
+        }
+
+        vec![frame.into_geometry()]
     }
 
     fn mouse_interaction(
         &self,
-        _state: &(),
+        _state: &Self::State,
         bounds: Rectangle,
         cursor: mouse::Cursor,
     ) -> mouse::Interaction {

--- a/src/ui/widget/dynamic_text_input.rs
+++ b/src/ui/widget/dynamic_text_input.rs
@@ -392,30 +392,27 @@ fn handle_enter_event<Message: Clone, Renderer: text::Renderer>(
             }
         }
         Event::Mouse(mouse::Event::ButtonReleased(mouse::Button::Left))
-        | Event::Touch(touch::Event::FingerLifted { .. }) => {
-            if state.is_pressed {
-                state.is_pressed = false;
+        | Event::Touch(touch::Event::FingerLifted { .. })
+            if state.is_pressed =>
+        {
+            state.is_pressed = false;
 
-                let bounds = layout.bounds();
+            let bounds = layout.bounds();
 
-                if cursor.is_over(bounds)
-                    && let Some(cursor_position) = cursor.position()
-                {
-                    let new_click = mouse::Click::new(
-                        cursor_position,
-                        mouse::Button::Left,
-                        state.previous_click,
-                    );
+            if cursor.is_over(bounds)
+                && let Some(cursor_position) = cursor.position()
+            {
+                let new_click =
+                    mouse::Click::new(cursor_position, mouse::Button::Left, state.previous_click);
 
-                    state.previous_click = Some(new_click);
+                state.previous_click = Some(new_click);
 
-                    if matches!(new_click.kind(), mouse::click::Kind::Double) {
-                        enter_edit_mode::<Message, Renderer>(tree, shell, on_enter);
-                    }
+                if matches!(new_click.kind(), mouse::click::Kind::Double) {
+                    enter_edit_mode::<Message, Renderer>(tree, shell, on_enter);
                 }
-
-                shell.capture_event();
             }
+
+            shell.capture_event();
         }
         Event::Touch(touch::Event::FingerLost { .. }) => {
             state.is_pressed = false;

--- a/src/ui/widget/mod.rs
+++ b/src/ui/widget/mod.rs
@@ -1,3 +1,4 @@
+pub mod canvas_toggle;
 pub mod dynamic_text_input;
 pub mod power_button;
 pub mod suggestion_text_input;

--- a/src/ui/widget/mod.rs
+++ b/src/ui/widget/mod.rs
@@ -1,1 +1,2 @@
 pub mod dynamic_text_input;
+pub mod suggestion_text_input;

--- a/src/ui/widget/mod.rs
+++ b/src/ui/widget/mod.rs
@@ -1,4 +1,5 @@
 pub mod canvas_toggle;
 pub mod dynamic_text_input;
 pub mod power_button;
+pub mod restart_button;
 pub mod suggestion_text_input;

--- a/src/ui/widget/mod.rs
+++ b/src/ui/widget/mod.rs
@@ -1,2 +1,3 @@
 pub mod dynamic_text_input;
+pub mod power_button;
 pub mod suggestion_text_input;

--- a/src/ui/widget/power_button.rs
+++ b/src/ui/widget/power_button.rs
@@ -3,7 +3,7 @@ use iced::widget::canvas::{Frame, LineCap, Path, Stroke};
 use iced::{Point, Radians, Theme};
 use std::f32::consts::PI;
 
-pub fn draw_power_button(theme: &Theme, frame: &mut Frame, enabled: bool) {
+pub fn draw(theme: &Theme, frame: &mut Frame, enabled: bool) {
     let size = frame.size();
     let cx = size.width / 2.0;
     let cy = size.height / 2.0;
@@ -15,7 +15,7 @@ pub fn draw_power_button(theme: &Theme, frame: &mut Frame, enabled: bool) {
     let arc_r = dim * 0.30; // power arc radius
     let stroke_w = dim * 0.07;
 
-    // ── Colors ───────────────────────────────────────────────────────────────
+    // Colors
     let (icon_color, bg_color) = if enabled {
         (
             theme.extended_palette().primary.base.color,
@@ -37,7 +37,7 @@ pub fn draw_power_button(theme: &Theme, frame: &mut Frame, enabled: bool) {
         },
     );
 
-    // ── Power arc ────────────────────────────────────────────────────────────
+    // Power arc
     // Gap of 70° centered at the top (-π/2 in screen coords).
     // Arc drawn from right edge of gap → clockwise around → left edge of gap.
     let gap_half = 35.0_f32.to_radians(); // half the gap angle
@@ -59,10 +59,10 @@ pub fn draw_power_button(theme: &Theme, frame: &mut Frame, enabled: bool) {
         Stroke::default()
             .with_color(icon_color)
             .with_width(stroke_w)
-            .with_line_cap(LineCap::Round),
+            .with_line_cap(LineCap::Butt),
     );
 
-    // ── Power line (vertical, through the gap) ───────────────────────────────
+    // Power line (vertical, through the gap)
     // Runs from ~20% inside the radius up to the circumference.
     let line = Path::new(|b| {
         b.move_to(Point::new(cx, cy - arc_r * 0.18));
@@ -74,6 +74,6 @@ pub fn draw_power_button(theme: &Theme, frame: &mut Frame, enabled: bool) {
         Stroke::default()
             .with_color(icon_color)
             .with_width(stroke_w)
-            .with_line_cap(LineCap::Round),
+            .with_line_cap(LineCap::Butt),
     );
 }

--- a/src/ui/widget/power_button.rs
+++ b/src/ui/widget/power_button.rs
@@ -1,0 +1,155 @@
+use crate::Message;
+use iced::advanced::graphics::core::event::Event;
+use iced::widget::canvas::{Frame, Geometry, LineCap, Path, Stroke};
+use iced::widget::{Action, canvas};
+use iced::{Point, Radians, Rectangle, Renderer, Theme, mouse};
+use std::f32::consts::PI;
+
+pub struct PowerButton<'a> {
+    is_checked: bool,
+    on_toggle: Option<Box<dyn Fn(bool) -> Message + 'a>>,
+    cache: &'a canvas::Cache,
+}
+
+impl<'a> PowerButton<'a> {
+    pub fn new(is_checked: bool, cache: &'a canvas::Cache) -> Self {
+        Self {
+            is_checked,
+            on_toggle: None,
+            cache,
+        }
+    }
+
+    pub fn on_toggle<F>(mut self, f: F) -> Self
+    where
+        F: 'a + Fn(bool) -> Message,
+    {
+        self.on_toggle = Some(Box::new(f));
+        self
+    }
+}
+
+impl<'a> canvas::Program<Message> for PowerButton<'a> {
+    type State = ();
+
+    fn update(
+        &self,
+        _state: &mut (),
+        event: &Event,
+        bounds: Rectangle,
+        cursor: mouse::Cursor,
+    ) -> Option<Action<Message>> {
+        if let Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) = event
+            && cursor.is_over(bounds)
+            && let Some(on_toggle) = &self.on_toggle
+        {
+            Some(Action::publish(on_toggle(!self.is_checked)))
+        } else {
+            None
+        }
+    }
+
+    fn draw(
+        &self,
+        _state: &(),
+        renderer: &Renderer,
+        theme: &Theme,
+        bounds: Rectangle,
+        _cursor: mouse::Cursor,
+    ) -> Vec<Geometry<Renderer>> {
+        let geo = self.cache.draw(renderer, bounds.size(), |frame| {
+            draw_power_button(theme, frame, self.is_checked);
+        });
+        vec![geo]
+    }
+
+    fn mouse_interaction(
+        &self,
+        _state: &(),
+        bounds: Rectangle,
+        cursor: mouse::Cursor,
+    ) -> mouse::Interaction {
+        if cursor.is_over(bounds) {
+            mouse::Interaction::Pointer
+        } else {
+            mouse::Interaction::default()
+        }
+    }
+}
+
+// ── Drawing logic ─────────────────────────────────────────────────────────────
+
+fn draw_power_button(theme: &Theme, frame: &mut Frame, enabled: bool) {
+    let size = frame.size();
+    let cx = size.width / 2.0;
+    let cy = size.height / 2.0;
+    let center = Point::new(cx, cy);
+
+    // Scale everything relative to the smaller dimension
+    let dim = size.width.min(size.height);
+    let bg_r = dim * 0.46; // background circle radius
+    let arc_r = dim * 0.30; // power arc radius
+    let stroke_w = dim * 0.07;
+
+    // ── Colors ───────────────────────────────────────────────────────────────
+    let (icon_color, bg_color) = if enabled {
+        (
+            theme.extended_palette().primary.base.color,
+            theme.extended_palette().background.weaker.color,
+        )
+    } else {
+        (
+            theme.extended_palette().secondary.base.color,
+            theme.extended_palette().background.weaker.color,
+        )
+    };
+
+    let bg_path = Path::new(|b| b.circle(center, bg_r));
+    frame.fill(
+        &bg_path,
+        canvas::Fill {
+            style: canvas::Style::Solid(bg_color),
+            ..canvas::Fill::default()
+        },
+    );
+
+    // ── Power arc ────────────────────────────────────────────────────────────
+    // Gap of 70° centered at the top (-π/2 in screen coords).
+    // Arc drawn from right edge of gap → clockwise around → left edge of gap.
+    let gap_half = 35.0_f32.to_radians(); // half the gap angle
+    let top = -PI / 2.0; // top of circle (-90°)
+    let start = top + gap_half; // right side of gap  ≈ -55°
+    let end = top - gap_half + 2.0 * PI; // left side of gap   ≈ 235° (going all the way around)
+
+    let arc = Path::new(|b| {
+        b.arc(canvas::path::Arc {
+            center,
+            radius: arc_r,
+            start_angle: Radians(start),
+            end_angle: Radians(end),
+        });
+    });
+
+    frame.stroke(
+        &arc,
+        Stroke::default()
+            .with_color(icon_color)
+            .with_width(stroke_w)
+            .with_line_cap(LineCap::Round),
+    );
+
+    // ── Power line (vertical, through the gap) ───────────────────────────────
+    // Runs from ~20% inside the radius up to the circumference.
+    let line = Path::new(|b| {
+        b.move_to(Point::new(cx, cy - arc_r * 0.18));
+        b.line_to(Point::new(cx, cy - arc_r));
+    });
+
+    frame.stroke(
+        &line,
+        Stroke::default()
+            .with_color(icon_color)
+            .with_width(stroke_w)
+            .with_line_cap(LineCap::Round),
+    );
+}

--- a/src/ui/widget/power_button.rs
+++ b/src/ui/widget/power_button.rs
@@ -1,85 +1,9 @@
-use crate::Message;
-use iced::advanced::graphics::core::event::Event;
-use iced::widget::canvas::{Frame, Geometry, LineCap, Path, Stroke};
-use iced::widget::{Action, canvas};
-use iced::{Point, Radians, Rectangle, Renderer, Theme, mouse};
+use iced::widget::canvas;
+use iced::widget::canvas::{Frame, LineCap, Path, Stroke};
+use iced::{Point, Radians, Theme};
 use std::f32::consts::PI;
 
-pub struct PowerButton<'a> {
-    is_checked: bool,
-    on_toggle: Option<Box<dyn Fn(bool) -> Message + 'a>>,
-    cache: &'a canvas::Cache,
-}
-
-impl<'a> PowerButton<'a> {
-    pub fn new(is_checked: bool, cache: &'a canvas::Cache) -> Self {
-        Self {
-            is_checked,
-            on_toggle: None,
-            cache,
-        }
-    }
-
-    pub fn on_toggle<F>(mut self, f: F) -> Self
-    where
-        F: 'a + Fn(bool) -> Message,
-    {
-        self.on_toggle = Some(Box::new(f));
-        self
-    }
-}
-
-impl<'a> canvas::Program<Message> for PowerButton<'a> {
-    type State = ();
-
-    fn update(
-        &self,
-        _state: &mut (),
-        event: &Event,
-        bounds: Rectangle,
-        cursor: mouse::Cursor,
-    ) -> Option<Action<Message>> {
-        if let Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)) = event
-            && cursor.is_over(bounds)
-            && let Some(on_toggle) = &self.on_toggle
-        {
-            Some(Action::publish(on_toggle(!self.is_checked)))
-        } else {
-            None
-        }
-    }
-
-    fn draw(
-        &self,
-        _state: &(),
-        renderer: &Renderer,
-        theme: &Theme,
-        bounds: Rectangle,
-        _cursor: mouse::Cursor,
-    ) -> Vec<Geometry<Renderer>> {
-        let geo = self.cache.draw(renderer, bounds.size(), |frame| {
-            draw_power_button(theme, frame, self.is_checked);
-        });
-        vec![geo]
-    }
-
-    fn mouse_interaction(
-        &self,
-        _state: &(),
-        bounds: Rectangle,
-        cursor: mouse::Cursor,
-    ) -> mouse::Interaction {
-        if cursor.is_over(bounds) {
-            mouse::Interaction::Pointer
-        } else {
-            mouse::Interaction::default()
-        }
-    }
-}
-
-// ── Drawing logic ─────────────────────────────────────────────────────────────
-
-fn draw_power_button(theme: &Theme, frame: &mut Frame, enabled: bool) {
+pub fn draw_power_button(theme: &Theme, frame: &mut Frame, enabled: bool) {
     let size = frame.size();
     let cx = size.width / 2.0;
     let cy = size.height / 2.0;

--- a/src/ui/widget/power_button.rs
+++ b/src/ui/widget/power_button.rs
@@ -1,9 +1,10 @@
+use iced::mouse::Cursor;
 use iced::widget::canvas;
 use iced::widget::canvas::{Frame, LineCap, Path, Stroke};
-use iced::{Point, Radians, Theme};
+use iced::{Point, Radians, Rectangle, Theme};
 use std::f32::consts::PI;
 
-pub fn draw(theme: &Theme, frame: &mut Frame, enabled: bool) {
+pub fn draw(theme: &Theme, frame: &mut Frame, _bounds: Rectangle, _cursor: Cursor, enabled: bool) {
     let size = frame.size();
     let cx = size.width / 2.0;
     let cy = size.height / 2.0;

--- a/src/ui/widget/restart_button.rs
+++ b/src/ui/widget/restart_button.rs
@@ -45,7 +45,7 @@ pub fn draw(theme: &Theme, frame: &mut Frame, enabled: bool) {
     let arc_start = top - gap / 2.0;
     let arc_cut_start = bot - gap / 4.0;
     let arc_cut_end = bot + gap / 4.0;
-    let arc_end = top - 1.5 * gap + 2.0 * PI; // 300°  (clockwise, long way round)
+    let arc_end = top - 1.25 * gap + 2.0 * PI; // 300°  (clockwise, long way round)
 
     let arc = Path::new(|b| {
         b.arc(canvas::path::Arc {

--- a/src/ui/widget/restart_button.rs
+++ b/src/ui/widget/restart_button.rs
@@ -1,0 +1,96 @@
+use iced::widget::canvas;
+use iced::widget::canvas::{Frame, LineCap, Path, Stroke};
+use iced::{Point, Radians, Theme};
+use std::f32::consts::PI;
+
+pub fn draw(theme: &Theme, frame: &mut Frame, enabled: bool) {
+    let size = frame.size();
+    let cx = size.width / 2.0;
+    let cy = size.height / 2.0;
+    let center = Point::new(cx, cy);
+    let dim = size.width.min(size.height);
+    let bg_r = dim * 0.46;
+    let arc_r = dim * 0.30;
+    let stroke_w = dim * 0.07;
+    let arrow_size = dim * 0.13;
+
+    // secondary color when enabled; muted background-strong when disabled
+    let (icon_color, bg_color) = if enabled {
+        (
+            theme.extended_palette().secondary.base.color,
+            theme.extended_palette().background.weaker.color,
+        )
+    } else {
+        (
+            theme.extended_palette().background.strongest.color,
+            theme.extended_palette().background.weaker.color,
+        )
+    };
+
+    // Background circle
+    let bg_path = Path::new(|b| b.circle(center, bg_r));
+    frame.fill(
+        &bg_path,
+        canvas::Fill {
+            style: canvas::Style::Solid(bg_color),
+            ..canvas::Fill::default()
+        },
+    );
+
+    // Restart arc
+    // 300° clockwise arc, 60° gap left from the top.
+    let gap = 30.0_f32.to_radians();
+    let bot = PI / 2.0;
+    let top = -bot;
+    let arc_start = top - gap / 2.0;
+    let arc_cut_start = bot - gap / 4.0;
+    let arc_cut_end = bot + gap / 4.0;
+    let arc_end = top - 1.5 * gap + 2.0 * PI; // 300°  (clockwise, long way round)
+
+    let arc = Path::new(|b| {
+        b.arc(canvas::path::Arc {
+            center,
+            radius: arc_r,
+            start_angle: Radians(arc_start),
+            end_angle: Radians(arc_cut_start),
+        });
+        b.arc(canvas::path::Arc {
+            center,
+            radius: arc_r,
+            start_angle: Radians(arc_cut_end),
+            end_angle: Radians(arc_end),
+        });
+    });
+    frame.stroke(
+        &arc,
+        Stroke::default()
+            .with_color(icon_color)
+            .with_width(stroke_w)
+            .with_line_cap(LineCap::Butt),
+    );
+
+    let end_x = cx - gap * 16.0;
+    let end_y = cy - arc_r;
+
+    // Two wings ±35° from the back direction
+    let (s, c) = 45.0_f32.to_radians().sin_cos();
+    let w1 = (-c, -s); // rotate +35°
+    let w2 = (-c, s); // rotate -35°
+
+    let tip = Point::new(end_x, end_y);
+    let p1 = Point::new(end_x - w1.0 * arrow_size, end_y + w1.1 * arrow_size);
+    let p2 = Point::new(end_x - w2.0 * arrow_size, end_y + w2.1 * arrow_size);
+
+    let arrowhead = Path::new(|b| {
+        b.move_to(p1);
+        b.line_to(tip);
+        b.line_to(p2);
+    });
+    frame.stroke(
+        &arrowhead,
+        Stroke::default()
+            .with_color(icon_color)
+            .with_width(stroke_w * 0.75)
+            .with_line_cap(LineCap::Butt),
+    );
+}

--- a/src/ui/widget/restart_button.rs
+++ b/src/ui/widget/restart_button.rs
@@ -1,9 +1,10 @@
+use iced::mouse::Cursor;
 use iced::widget::canvas;
 use iced::widget::canvas::{Frame, LineCap, Path, Stroke};
-use iced::{Point, Radians, Theme};
+use iced::{Point, Radians, Rectangle, Theme};
 use std::f32::consts::PI;
 
-pub fn draw(theme: &Theme, frame: &mut Frame, enabled: bool) {
+pub fn draw(theme: &Theme, frame: &mut Frame, _bounds: Rectangle, _cursor: Cursor, enabled: bool) {
     let size = frame.size();
     let cx = size.width / 2.0;
     let cy = size.height / 2.0;

--- a/src/ui/widget/restart_button.rs
+++ b/src/ui/widget/restart_button.rs
@@ -73,10 +73,10 @@ pub fn draw(theme: &Theme, frame: &mut Frame, _bounds: Rectangle, _cursor: Curso
     let end_x = cx - gap * 16.0;
     let end_y = cy - arc_r;
 
-    // Two wings ±35° from the back direction
+    // Two wings ±45° from the back direction
     let (s, c) = 45.0_f32.to_radians().sin_cos();
-    let w1 = (-c, -s); // rotate +35°
-    let w2 = (-c, s); // rotate -35°
+    let w1 = (-c, -s); // rotate +45°
+    let w2 = (-c, s); // rotate -45°
 
     let tip = Point::new(end_x, end_y);
     let p1 = Point::new(end_x - w1.0 * arrow_size, end_y + w1.1 * arrow_size);

--- a/src/ui/widget/suggestion_text_input.rs
+++ b/src/ui/widget/suggestion_text_input.rs
@@ -1,0 +1,774 @@
+use iced::keyboard;
+use iced::keyboard::key;
+use iced::mouse;
+use iced::overlay;
+use iced::overlay::menu;
+use iced::time::Instant;
+use iced::{Element, Event, Length, Padding, Pixels, Rectangle, Size, Theme, Vector};
+use std::cell::RefCell;
+
+use iced::advanced::text::LineHeight;
+use iced::advanced::{Clipboard, Layout, Shell, Widget, layout, renderer, text, widget};
+use iced::widget::{TextInput, text_input};
+use std::fmt::Display;
+
+pub struct SuggestionTextInput<'a, T, Message, Theme = iced::Theme, Renderer = iced::Renderer>
+where
+    Theme: Catalog,
+    Renderer: text::Renderer,
+{
+    state: &'a State<T>,
+    text_input: TextInput<'a, TextInputEvent, Theme, Renderer>,
+    font: Option<Renderer::Font>,
+    on_open: Option<Message>,
+    on_close: Option<Message>,
+    on_input: Box<dyn Fn(String) -> Message>,
+    padding: Padding,
+    size: Option<f32>,
+    text_shaping: text::Shaping,
+    menu_class: <Theme as menu::Catalog>::Class<'a>,
+    menu_height: Length,
+}
+
+impl<'a, T, Message, Theme, Renderer> SuggestionTextInput<'a, T, Message, Theme, Renderer>
+where
+    T: Display + Clone,
+    Theme: Catalog,
+    Renderer: text::Renderer,
+{
+    /// Creates a new [`SuggestionTextInput`] with the given list of options, a placeholder,
+    /// the current selected value, and the message to produce when an option is
+    /// selected.
+    pub fn new(
+        state: &'a State<T>,
+        placeholder: &str,
+        on_input: impl Fn(String) -> Message + 'static,
+    ) -> Self {
+        let text_input = TextInput::new(placeholder, &state.value())
+            .on_input(TextInputEvent::TextChanged)
+            .class(Theme::default_input());
+
+        Self {
+            state,
+            text_input,
+            font: None,
+            on_input: Box::new(on_input),
+            on_open: None,
+            on_close: None,
+            padding: text_input::DEFAULT_PADDING,
+            size: None,
+            text_shaping: text::Shaping::default(),
+            menu_class: <Theme as Catalog>::default_menu(),
+            menu_height: Length::Shrink,
+        }
+    }
+
+    /// Sets the message that will be produced when the  [`SuggestionTextInput`] is
+    /// opened.
+    pub fn on_open(mut self, message: Message) -> Self {
+        self.on_open = Some(message);
+        self
+    }
+
+    /// Sets the message that will be produced when the outside area
+    /// of the [`SuggestionTextInput`] is pressed.
+    pub fn on_close(mut self, message: Message) -> Self {
+        self.on_close = Some(message);
+        self
+    }
+
+    /// Sets the [`Padding`] of the [`SuggestionTextInput`].
+    pub fn padding(mut self, padding: impl Into<Padding>) -> Self {
+        self.padding = padding.into();
+        self.text_input = self.text_input.padding(self.padding);
+        self
+    }
+
+    /// Sets the [`Renderer::Font`] of the [`SuggestionTextInput`].
+    ///
+    /// [`Renderer::Font`]: text::Renderer
+    pub fn font(mut self, font: Renderer::Font) -> Self {
+        self.text_input = self.text_input.font(font);
+        self.font = Some(font);
+        self
+    }
+
+    /// Sets the [`text_input::Icon`] of the [`SuggestionTextInput`].
+    pub fn icon(mut self, icon: text_input::Icon<Renderer::Font>) -> Self {
+        self.text_input = self.text_input.icon(icon);
+        self
+    }
+
+    /// Sets the text size of the [`SuggestionTextInput`].
+    pub fn size(mut self, size: impl Into<Pixels>) -> Self {
+        let size = size.into();
+
+        self.text_input = self.text_input.size(size);
+        self.size = Some(size.0);
+
+        self
+    }
+
+    /// Sets the [`LineHeight`] of the [`SuggestionTextInput`].
+    pub fn line_height(self, line_height: impl Into<LineHeight>) -> Self {
+        Self {
+            text_input: self.text_input.line_height(line_height),
+            ..self
+        }
+    }
+
+    /// Sets the width of the [`SuggestionTextInput`].
+    pub fn width(self, width: impl Into<Length>) -> Self {
+        Self {
+            text_input: self.text_input.width(width),
+            ..self
+        }
+    }
+
+    /// Sets the height of the menu of the [`SuggestionTextInput`].
+    pub fn menu_height(mut self, menu_height: impl Into<Length>) -> Self {
+        self.menu_height = menu_height.into();
+        self
+    }
+
+    /// Sets the [`text::Shaping`] strategy of the [`SuggestionTextInput`].
+    pub fn text_shaping(mut self, shaping: text::Shaping) -> Self {
+        self.text_shaping = shaping;
+        self
+    }
+
+    /// Sets the style of the input of the [`SuggestionTextInput`].
+    #[must_use]
+    pub fn input_style(
+        mut self,
+        style: impl Fn(&Theme, text_input::Status) -> text_input::Style + 'a,
+    ) -> Self
+    where
+        <Theme as text_input::Catalog>::Class<'a>: From<text_input::StyleFn<'a, Theme>>,
+    {
+        self.text_input = self.text_input.style(style);
+        self
+    }
+
+    /// Sets the style of the menu of the [`SuggestionTextInput`].
+    #[must_use]
+    pub fn menu_style(mut self, style: impl Fn(&Theme) -> menu::Style + 'a) -> Self
+    where
+        <Theme as menu::Catalog>::Class<'a>: From<menu::StyleFn<'a, Theme>>,
+    {
+        self.menu_class = (Box::new(style) as menu::StyleFn<'a, Theme>).into();
+        self
+    }
+
+    /// Sets the style class of the input of the [`SuggestionTextInput`].
+    #[must_use]
+    pub fn input_class(
+        mut self,
+        class: impl Into<<Theme as text_input::Catalog>::Class<'a>>,
+    ) -> Self {
+        self.text_input = self.text_input.class(class);
+        self
+    }
+
+    /// Sets the style class of the menu of the [`SuggestionTextInput`].
+    #[must_use]
+    pub fn menu_class(mut self, class: impl Into<<Theme as menu::Catalog>::Class<'a>>) -> Self {
+        self.menu_class = class.into();
+        self
+    }
+}
+
+/// The local state of a [`ComboBox`].
+#[derive(Debug, Clone)]
+pub struct State<T> {
+    options: Vec<T>,
+    pub(super) inner: RefCell<Inner<T>>,
+}
+
+#[derive(Debug, Clone)]
+struct Inner<T> {
+    value: String,
+    option_matchers: Vec<String>,
+    filtered_options: Filtered<T>,
+}
+
+#[derive(Debug, Clone)]
+struct Filtered<T> {
+    options: Vec<T>,
+    updated: Instant,
+}
+
+impl<T> State<T>
+where
+    T: Display + Clone,
+{
+    /// Creates a new [`State`] for a [`ComboBox`] with the given list of options.
+    pub fn new(options: Vec<T>) -> Self {
+        Self::with_selection(options, None)
+    }
+
+    /// Creates a new [`State`] for a [`ComboBox`] with the given list of options
+    /// and selected value.
+    pub fn with_selection(options: Vec<T>, selection: Option<&T>) -> Self {
+        let value = selection.map(T::to_string).unwrap_or_default();
+
+        // Pre-build "matcher" strings ahead of time so that search is fast
+        let option_matchers = build_matchers(&options);
+
+        let filtered_options = Filtered::new(
+            search(&options, &option_matchers, &value)
+                .cloned()
+                .collect(),
+        );
+
+        Self {
+            options,
+            inner: RefCell::new(Inner {
+                value,
+                option_matchers,
+                filtered_options,
+            }),
+        }
+    }
+
+    /// Returns the options of the [`State`].
+    ///
+    /// These are the options provided when the [`State`]
+    /// was constructed with [`State::new`].
+    pub fn options(&self) -> &[T] {
+        &self.options
+    }
+
+    /// Pushes a new option to the [`State`].
+    pub fn push(&mut self, new_option: T) {
+        let mut inner = self.inner.borrow_mut();
+
+        inner.option_matchers.push(build_matcher(&new_option));
+        self.options.push(new_option);
+
+        inner.filtered_options = Filtered::new(
+            search(&self.options, &inner.option_matchers, &inner.value)
+                .cloned()
+                .collect(),
+        );
+    }
+
+    /// Returns ownership of the options of the [`State`].
+    pub fn into_options(self) -> Vec<T> {
+        self.options
+    }
+
+    fn value(&self) -> String {
+        let inner = self.inner.borrow();
+
+        inner.value.clone()
+    }
+
+    fn with_inner<O>(&self, f: impl FnOnce(&Inner<T>) -> O) -> O {
+        let inner = self.inner.borrow();
+
+        f(&inner)
+    }
+
+    fn with_inner_mut(&self, f: impl FnOnce(&mut Inner<T>)) {
+        let mut inner = self.inner.borrow_mut();
+
+        f(&mut inner);
+    }
+
+    fn sync_filtered_options(&self, options: &mut Filtered<T>) {
+        let inner = self.inner.borrow();
+
+        inner.filtered_options.sync(options);
+    }
+}
+
+impl<T> Default for State<T>
+where
+    T: Display + Clone,
+{
+    fn default() -> Self {
+        Self::new(Vec::new())
+    }
+}
+
+impl<T> Filtered<T>
+where
+    T: Clone,
+{
+    fn new(options: Vec<T>) -> Self {
+        Self {
+            options,
+            updated: Instant::now(),
+        }
+    }
+
+    fn empty() -> Self {
+        Self {
+            options: vec![],
+            updated: Instant::now(),
+        }
+    }
+
+    fn update(&mut self, options: Vec<T>) {
+        self.options = options;
+        self.updated = Instant::now();
+    }
+
+    fn sync(&self, other: &mut Filtered<T>) {
+        if other.updated != self.updated {
+            *other = self.clone();
+        }
+    }
+}
+
+struct Menu<T> {
+    menu: menu::State,
+    hovered_option: Option<usize>,
+    new_selection: Option<T>,
+    filtered_options: Filtered<T>,
+}
+
+#[derive(Debug, Clone)]
+enum TextInputEvent {
+    TextChanged(String),
+}
+
+impl<T, Message, Theme, Renderer> Widget<Message, Theme, Renderer>
+    for SuggestionTextInput<'_, T, Message, Theme, Renderer>
+where
+    T: Display + Clone + 'static,
+    Message: Clone,
+    Theme: Catalog,
+    Renderer: text::Renderer,
+{
+    fn size(&self) -> Size<Length> {
+        Widget::<TextInputEvent, Theme, Renderer>::size(&self.text_input)
+    }
+
+    fn layout(
+        &mut self,
+        tree: &mut widget::Tree,
+        renderer: &Renderer,
+        limits: &layout::Limits,
+    ) -> layout::Node {
+        let is_focused = {
+            let text_input_state = tree.children[0]
+                .state
+                .downcast_ref::<text_input::State<Renderer::Paragraph>>();
+
+            text_input_state.is_focused()
+        };
+
+        self.text_input.layout(
+            &mut tree.children[0],
+            renderer,
+            limits,
+            (!is_focused).then_some(&text_input::Value::new(&self.state.inner.borrow().value)),
+        )
+    }
+
+    fn draw(
+        &self,
+        tree: &widget::Tree,
+        renderer: &mut Renderer,
+        theme: &Theme,
+        _style: &renderer::Style,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+    ) {
+        let is_focused = {
+            let text_input_state = tree.children[0]
+                .state
+                .downcast_ref::<text_input::State<Renderer::Paragraph>>();
+
+            text_input_state.is_focused()
+        };
+
+        let selection = if is_focused || self.state.value().is_empty() {
+            None
+        } else {
+            Some(&text_input::Value::new(&self.state.value()))
+        };
+
+        self.text_input.draw(
+            &tree.children[0],
+            renderer,
+            theme,
+            layout,
+            cursor,
+            selection,
+            viewport,
+        );
+    }
+
+    fn tag(&self) -> widget::tree::Tag {
+        widget::tree::Tag::of::<Menu<T>>()
+    }
+
+    fn state(&self) -> widget::tree::State {
+        widget::tree::State::new(Menu::<T> {
+            menu: menu::State::new(),
+            filtered_options: Filtered::empty(),
+            hovered_option: Some(0),
+            new_selection: None,
+        })
+    }
+
+    fn children(&self) -> Vec<widget::Tree> {
+        vec![widget::Tree::new(&self.text_input as &dyn Widget<_, _, _>)]
+    }
+
+    fn diff(&self, _tree: &mut widget::Tree) {
+        // do nothing so the children don't get cleared
+    }
+
+    fn update(
+        &mut self,
+        tree: &mut widget::Tree,
+        event: &Event,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        renderer: &Renderer,
+        clipboard: &mut dyn Clipboard,
+        shell: &mut Shell<'_, Message>,
+        viewport: &Rectangle,
+    ) {
+        let menu = tree.state.downcast_mut::<Menu<T>>();
+
+        let started_focused = {
+            let text_input_state = tree.children[0]
+                .state
+                .downcast_ref::<text_input::State<Renderer::Paragraph>>();
+
+            text_input_state.is_focused()
+        };
+        // This is intended to check whether the message buffer was empty,
+        // since `Shell` does not expose such functionality.
+        let mut published_message_to_shell = false;
+
+        // Create a new list of local messages
+        let mut local_messages = Vec::new();
+        let mut local_shell = Shell::new(&mut local_messages);
+
+        // Provide it to the widget
+        self.text_input.update(
+            &mut tree.children[0],
+            event,
+            layout,
+            cursor,
+            renderer,
+            clipboard,
+            &mut local_shell,
+            viewport,
+        );
+
+        if local_shell.is_event_captured() {
+            shell.capture_event();
+        }
+
+        shell.request_redraw_at(local_shell.redraw_request());
+        shell.request_input_method(local_shell.input_method());
+
+        // Then finally react to them here
+        for message in local_messages {
+            let TextInputEvent::TextChanged(new_value) = message;
+
+            shell.publish((self.on_input)(new_value.clone()));
+
+            // Couple the filtered options with the `ComboBox`
+            // value and only recompute them when the value changes,
+            // instead of doing it in every `view` call
+            self.state.with_inner_mut(|state| {
+                menu.hovered_option = Some(0);
+                state.value = new_value;
+
+                state.filtered_options.update(
+                    search(&self.state.options, &state.option_matchers, &state.value)
+                        .cloned()
+                        .collect(),
+                );
+            });
+            shell.invalidate_layout();
+            shell.request_redraw();
+        }
+
+        let is_focused = {
+            let text_input_state = tree.children[0]
+                .state
+                .downcast_ref::<text_input::State<Renderer::Paragraph>>();
+
+            text_input_state.is_focused()
+        };
+
+        if is_focused {
+            self.state.with_inner(|state| {
+                if let Event::Keyboard(keyboard::Event::KeyPressed {
+                    key: keyboard::Key::Named(named_key),
+                    modifiers,
+                    ..
+                }) = event
+                {
+                    let shift_modifier = modifiers.shift();
+                    match (named_key, shift_modifier) {
+                        (key::Named::Enter, _) => {
+                            if let Some(index) = &menu.hovered_option
+                                && let Some(option) = state.filtered_options.options.get(*index)
+                            {
+                                menu.new_selection = Some(option.clone());
+                            }
+
+                            shell.capture_event();
+                            shell.request_redraw();
+                        }
+                        (key::Named::ArrowUp, _) | (key::Named::Tab, true) => {
+                            if let Some(index) = &mut menu.hovered_option {
+                                if *index == 0 {
+                                    *index = state.filtered_options.options.len().saturating_sub(1);
+                                } else {
+                                    *index = index.saturating_sub(1);
+                                }
+                            } else {
+                                menu.hovered_option = Some(0);
+                            }
+
+                            shell.capture_event();
+                            shell.request_redraw();
+                        }
+                        (key::Named::ArrowDown, _) | (key::Named::Tab, false)
+                            if !modifiers.shift() =>
+                        {
+                            if let Some(index) = &mut menu.hovered_option {
+                                if *index >= state.filtered_options.options.len().saturating_sub(1)
+                                {
+                                    *index = 0;
+                                } else {
+                                    *index = index.saturating_add(1).min(
+                                        state.filtered_options.options.len().saturating_sub(1),
+                                    );
+                                }
+                            } else {
+                                menu.hovered_option = Some(0);
+                            }
+
+                            shell.capture_event();
+                            shell.request_redraw();
+                        }
+                        _ => {}
+                    }
+                }
+            });
+        }
+
+        // If the overlay menu has selected something
+        self.state.with_inner_mut(|state| {
+            if let Some(selection) = menu.new_selection.take() {
+                // Clear the value and reset the options and menu
+                state.value = String::new();
+                state.filtered_options.update(self.state.options.clone());
+                menu.menu = menu::State::default();
+
+                // Notify the selection
+                shell.publish((self.on_input)(selection.to_string()));
+                published_message_to_shell = true;
+
+                // Unfocus the input
+                let mut local_messages = Vec::new();
+                let mut local_shell = Shell::new(&mut local_messages);
+                self.text_input.update(
+                    &mut tree.children[0],
+                    &Event::Mouse(mouse::Event::ButtonPressed(mouse::Button::Left)),
+                    layout,
+                    mouse::Cursor::Unavailable,
+                    renderer,
+                    clipboard,
+                    &mut local_shell,
+                    viewport,
+                );
+                shell.request_input_method(local_shell.input_method());
+            }
+        });
+
+        let is_focused = {
+            let text_input_state = tree.children[0]
+                .state
+                .downcast_ref::<text_input::State<Renderer::Paragraph>>();
+
+            text_input_state.is_focused()
+        };
+
+        if started_focused != is_focused {
+            // Focus changed, invalidate widget tree to force a fresh `view`
+            shell.invalidate_widgets();
+
+            if !published_message_to_shell {
+                if is_focused {
+                    if let Some(on_open) = self.on_open.take() {
+                        shell.publish(on_open);
+                    }
+                } else if let Some(on_close) = self.on_close.take() {
+                    shell.publish(on_close);
+                }
+            }
+        }
+    }
+
+    fn mouse_interaction(
+        &self,
+        tree: &widget::Tree,
+        layout: Layout<'_>,
+        cursor: mouse::Cursor,
+        viewport: &Rectangle,
+        renderer: &Renderer,
+    ) -> mouse::Interaction {
+        self.text_input
+            .mouse_interaction(&tree.children[0], layout, cursor, viewport, renderer)
+    }
+
+    fn overlay<'b>(
+        &'b mut self,
+        tree: &'b mut widget::Tree,
+        layout: Layout<'_>,
+        _renderer: &Renderer,
+        viewport: &Rectangle,
+        translation: Vector,
+    ) -> Option<overlay::Element<'b, Message, Theme, Renderer>> {
+        let is_focused = {
+            let text_input_state = tree.children[0]
+                .state
+                .downcast_ref::<text_input::State<Renderer::Paragraph>>();
+
+            text_input_state.is_focused()
+        };
+
+        if is_focused {
+            let Menu {
+                menu,
+                filtered_options,
+                hovered_option,
+                ..
+            } = tree.state.downcast_mut::<Menu<T>>();
+
+            self.state.sync_filtered_options(filtered_options);
+
+            if filtered_options.options.is_empty() {
+                None
+            } else {
+                let bounds = layout.bounds();
+
+                let mut menu = menu::Menu::new(
+                    menu,
+                    &filtered_options.options,
+                    hovered_option,
+                    |selection| {
+                        self.state.with_inner_mut(|state| {
+                            state.value = String::new();
+                            state.filtered_options.update(self.state.options.clone());
+                        });
+
+                        tree.children[0]
+                            .state
+                            .downcast_mut::<text_input::State<Renderer::Paragraph>>()
+                            .unfocus();
+
+                        (self.on_input)(selection.to_string())
+                    },
+                    None,
+                    &self.menu_class,
+                )
+                .width(bounds.width)
+                .padding(self.padding)
+                .text_shaping(self.text_shaping);
+
+                if let Some(font) = self.font {
+                    menu = menu.font(font);
+                }
+
+                if let Some(size) = self.size {
+                    menu = menu.text_size(size);
+                }
+
+                Some(menu.overlay(
+                    layout.position() + translation,
+                    *viewport,
+                    bounds.height,
+                    self.menu_height,
+                ))
+            }
+        } else {
+            None
+        }
+    }
+}
+
+impl<'a, T, Message, Theme, Renderer> From<SuggestionTextInput<'a, T, Message, Theme, Renderer>>
+    for Element<'a, Message, Theme, Renderer>
+where
+    T: Display + Clone + 'static,
+    Message: Clone + 'a,
+    Theme: Catalog + 'a,
+    Renderer: text::Renderer + 'a,
+{
+    fn from(combo_box: SuggestionTextInput<'a, T, Message, Theme, Renderer>) -> Self {
+        Self::new(combo_box)
+    }
+}
+
+/// The theme catalog of a [`SuggestionTextInput`].
+pub trait Catalog: text_input::Catalog + menu::Catalog {
+    /// The default class for the text input of the [`SuggestionTextInput`].
+    fn default_input<'a>() -> <Self as text_input::Catalog>::Class<'a> {
+        <Self as text_input::Catalog>::default()
+    }
+
+    /// The default class for the menu of the [`SuggestionTextInput`].
+    fn default_menu<'a>() -> <Self as menu::Catalog>::Class<'a> {
+        <Self as menu::Catalog>::default()
+    }
+}
+
+impl Catalog for Theme {}
+
+fn search<'a, T, A>(
+    options: impl IntoIterator<Item = T> + 'a,
+    option_matchers: impl IntoIterator<Item = &'a A> + 'a,
+    query: &'a str,
+) -> impl Iterator<Item = T> + 'a
+where
+    A: AsRef<str> + 'a,
+{
+    let query: Vec<String> = query
+        .to_lowercase()
+        .split(|c: char| !c.is_ascii_alphanumeric())
+        .map(String::from)
+        .collect();
+
+    options
+        .into_iter()
+        .zip(option_matchers)
+        // Make sure each part of the query is found in the option
+        .filter_map(move |(option, matcher)| {
+            if query.iter().all(|part| matcher.as_ref().contains(part)) {
+                Some(option)
+            } else {
+                None
+            }
+        })
+}
+
+fn build_matchers<'a, T>(options: impl IntoIterator<Item = T> + 'a) -> Vec<String>
+where
+    T: Display + 'a,
+{
+    options.into_iter().map(build_matcher).collect()
+}
+
+fn build_matcher<T>(option: T) -> String
+where
+    T: Display,
+{
+    let mut matcher = option.to_string();
+    matcher.retain(|c| c.is_ascii_alphanumeric());
+    matcher.to_lowercase()
+}

--- a/src/ui/widget/suggestion_text_input.rs
+++ b/src/ui/widget/suggestion_text_input.rs
@@ -1,3 +1,60 @@
+//! Combo boxes display a dropdown list of searchable and selectable options.
+//!
+//! # Example
+//! ```no_run
+//! # mod iced { pub mod widget { pub use iced_widget::*; } pub use iced_widget::Renderer; pub use iced_widget::core::*; }
+//! # pub type Element<'a, Message> = iced_widget::core::Element<'a, Message, iced_widget::Theme, iced_widget::Renderer>;
+//! #
+//! use iced::widget::combo_box;
+//!
+//! struct State {
+//!    fruits: combo_box::State<Fruit>,
+//!    favorite: Option<Fruit>,
+//! }
+//!
+//! #[derive(Debug, Clone)]
+//! enum Fruit {
+//!     Apple,
+//!     Orange,
+//!     Strawberry,
+//!     Tomato,
+//! }
+//!
+//! #[derive(Debug, Clone)]
+//! enum Message {
+//!     FruitSelected(Fruit),
+//! }
+//!
+//! fn view(state: &State) -> Element<'_, Message> {
+//!     combo_box(
+//!         &state.fruits,
+//!         "Select your favorite fruit...",
+//!         state.favorite.as_ref(),
+//!         Message::FruitSelected
+//!     )
+//!     .into()
+//! }
+//!
+//! fn update(state: &mut State, message: Message) {
+//!     match message {
+//!         Message::FruitSelected(fruit) => {
+//!             state.favorite = Some(fruit);
+//!         }
+//!     }
+//! }
+//!
+//! impl std::fmt::Display for Fruit {
+//!     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+//!         f.write_str(match self {
+//!             Self::Apple => "Apple",
+//!             Self::Orange => "Orange",
+//!             Self::Strawberry => "Strawberry",
+//!             Self::Tomato => "Tomato",
+//!         })
+//!     }
+//! }
+//! ```
+use iced::advanced::{Clipboard, Layout, Shell, Widget, layout, renderer, text, widget};
 use iced::keyboard;
 use iced::keyboard::key;
 use iced::mouse;
@@ -5,13 +62,68 @@ use iced::overlay;
 use iced::overlay::menu;
 use iced::time::Instant;
 use iced::{Element, Event, Length, Padding, Pixels, Rectangle, Size, Theme, Vector};
-use std::cell::RefCell;
 
 use iced::advanced::text::LineHeight;
-use iced::advanced::{Clipboard, Layout, Shell, Widget, layout, renderer, text, widget};
 use iced::widget::{TextInput, text_input};
+use std::cell::RefCell;
 use std::fmt::Display;
 
+/// A widget for searching and selecting a single value from a list of options.
+///
+/// # Example
+/// ```no_run
+/// # mod iced { pub mod widget { pub use iced_widget::*; } pub use iced_widget::Renderer; pub use iced_widget::core::*; }
+/// # pub type Element<'a, Message> = iced_widget::core::Element<'a, Message, iced_widget::Theme, iced_widget::Renderer>;
+/// #
+/// use iced::widget::combo_box;
+///
+/// struct State {
+///    fruits: combo_box::State<Fruit>,
+///    favorite: Option<Fruit>,
+/// }
+///
+/// #[derive(Debug, Clone)]
+/// enum Fruit {
+///     Apple,
+///     Orange,
+///     Strawberry,
+///     Tomato,
+/// }
+///
+/// #[derive(Debug, Clone)]
+/// enum Message {
+///     FruitSelected(Fruit),
+/// }
+///
+/// fn view(state: &State) -> Element<'_, Message> {
+///     combo_box(
+///         &state.fruits,
+///         "Select your favorite fruit...",
+///         state.favorite.as_ref(),
+///         Message::FruitSelected
+///     )
+///     .into()
+/// }
+///
+/// fn update(state: &mut State, message: Message) {
+///     match message {
+///         Message::FruitSelected(fruit) => {
+///             state.favorite = Some(fruit);
+///         }
+///     }
+/// }
+///
+/// impl std::fmt::Display for Fruit {
+///     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+///         f.write_str(match self {
+///             Self::Apple => "Apple",
+///             Self::Orange => "Orange",
+///             Self::Strawberry => "Strawberry",
+///             Self::Tomato => "Tomato",
+///         })
+///     }
+/// }
+/// ```
 pub struct SuggestionTextInput<'a, T, Message, Theme = iced::Theme, Renderer = iced::Renderer>
 where
     Theme: Catalog,
@@ -20,9 +132,12 @@ where
     state: &'a State<T>,
     text_input: TextInput<'a, TextInputEvent, Theme, Renderer>,
     font: Option<Renderer::Font>,
+    selection: text_input::Value,
+    on_selected: Box<dyn Fn(T) -> Message>,
+    on_option_hovered: Option<Box<dyn Fn(T) -> Message>>,
     on_open: Option<Message>,
     on_close: Option<Message>,
-    on_input: Box<dyn Fn(String) -> Message>,
+    on_input: Option<Box<dyn Fn(String) -> Message>>,
     padding: Padding,
     size: Option<f32>,
     text_shaping: text::Shaping,
@@ -42,17 +157,23 @@ where
     pub fn new(
         state: &'a State<T>,
         placeholder: &str,
-        on_input: impl Fn(String) -> Message + 'static,
+        selection: Option<&T>,
+        on_selected: impl Fn(T) -> Message + 'static,
     ) -> Self {
         let text_input = TextInput::new(placeholder, &state.value())
             .on_input(TextInputEvent::TextChanged)
             .class(Theme::default_input());
 
+        let selection = selection.map(T::to_string).unwrap_or_default();
+
         Self {
             state,
             text_input,
             font: None,
-            on_input: Box::new(on_input),
+            selection: text_input::Value::new(&selection),
+            on_selected: Box::new(on_selected),
+            on_option_hovered: None,
+            on_input: None,
             on_open: None,
             on_close: None,
             padding: text_input::DEFAULT_PADDING,
@@ -61,6 +182,20 @@ where
             menu_class: <Theme as Catalog>::default_menu(),
             menu_height: Length::Shrink,
         }
+    }
+
+    /// Sets the message that should be produced when some text is typed into
+    /// the [`TextInput`] of the [`SuggestionTextInput`].
+    pub fn on_input(mut self, on_input: impl Fn(String) -> Message + 'static) -> Self {
+        self.on_input = Some(Box::new(on_input));
+        self
+    }
+
+    /// Sets the message that will be produced when an option of the
+    /// [`SuggestionTextInput`] is hovered using the arrow keys.
+    pub fn on_option_hovered(mut self, on_option_hovered: impl Fn(T) -> Message + 'static) -> Self {
+        self.on_option_hovered = Some(Box::new(on_option_hovered));
+        self
     }
 
     /// Sets the message that will be produced when the  [`SuggestionTextInput`] is
@@ -178,11 +313,11 @@ where
     }
 }
 
-/// The local state of a [`ComboBox`].
+/// The local state of a [`SuggestionTextInput`].
 #[derive(Debug, Clone)]
 pub struct State<T> {
     options: Vec<T>,
-    pub(super) inner: RefCell<Inner<T>>,
+    inner: RefCell<Inner<T>>,
 }
 
 #[derive(Debug, Clone)]
@@ -202,12 +337,12 @@ impl<T> State<T>
 where
     T: Display + Clone,
 {
-    /// Creates a new [`State`] for a [`ComboBox`] with the given list of options.
+    /// Creates a new [`State`] for a [`SuggestionTextInput`] with the given list of options.
     pub fn new(options: Vec<T>) -> Self {
         Self::with_selection(options, None)
     }
 
-    /// Creates a new [`State`] for a [`ComboBox`] with the given list of options
+    /// Creates a new [`State`] for a [`SuggestionTextInput`] with the given list of options
     /// and selected value.
     pub fn with_selection(options: Vec<T>, selection: Option<&T>) -> Self {
         let value = selection.map(T::to_string).unwrap_or_default();
@@ -364,7 +499,7 @@ where
             &mut tree.children[0],
             renderer,
             limits,
-            (!is_focused).then_some(&text_input::Value::new(&self.state.inner.borrow().value)),
+            (!is_focused).then_some(&self.selection),
         )
     }
 
@@ -386,10 +521,10 @@ where
             text_input_state.is_focused()
         };
 
-        let selection = if is_focused || self.state.value().is_empty() {
+        let selection = if is_focused || self.selection.is_empty() {
             None
         } else {
-            Some(&text_input::Value::new(&self.state.value()))
+            Some(&self.selection)
         };
 
         self.text_input.draw(
@@ -444,9 +579,6 @@ where
 
             text_input_state.is_focused()
         };
-        // This is intended to check whether the message buffer was empty,
-        // since `Shell` does not expose such functionality.
-        let mut published_message_to_shell = false;
 
         // Create a new list of local messages
         let mut local_messages = Vec::new();
@@ -475,9 +607,11 @@ where
         for message in local_messages {
             let TextInputEvent::TextChanged(new_value) = message;
 
-            shell.publish((self.on_input)(new_value.clone()));
+            if let Some(on_input) = &self.on_input {
+                shell.publish(on_input(new_value.clone()));
+            }
 
-            // Couple the filtered options with the `ComboBox`
+            // Couple the filtered options with the `SuggestionTextInput`
             // value and only recompute them when the value changes,
             // instead of doing it in every `view` call
             self.state.with_inner_mut(|state| {
@@ -504,6 +638,14 @@ where
 
         if is_focused {
             self.state.with_inner(|state| {
+                if !started_focused && let Some(on_option_hovered) = &mut self.on_option_hovered {
+                    let hovered_option = menu.hovered_option.unwrap_or(0);
+
+                    if let Some(option) = state.filtered_options.options.get(hovered_option) {
+                        shell.publish(on_option_hovered(option.clone()));
+                    }
+                }
+
                 if let Event::Keyboard(keyboard::Event::KeyPressed {
                     key: keyboard::Key::Named(named_key),
                     modifiers,
@@ -533,6 +675,15 @@ where
                                 menu.hovered_option = Some(0);
                             }
 
+                            if let Some(on_option_hovered) = &mut self.on_option_hovered
+                                && let Some(option) = menu
+                                    .hovered_option
+                                    .and_then(|index| state.filtered_options.options.get(index))
+                            {
+                                // Notify the selection
+                                shell.publish(on_option_hovered(option.clone()));
+                            }
+
                             shell.capture_event();
                             shell.request_redraw();
                         }
@@ -550,6 +701,15 @@ where
                                 }
                             } else {
                                 menu.hovered_option = Some(0);
+                            }
+
+                            if let Some(on_option_hovered) = &mut self.on_option_hovered
+                                && let Some(option) = menu
+                                    .hovered_option
+                                    .and_then(|index| state.filtered_options.options.get(index))
+                            {
+                                // Notify the selection
+                                shell.publish(on_option_hovered(option.clone()));
                             }
 
                             shell.capture_event();
@@ -570,8 +730,7 @@ where
                 menu.menu = menu::State::default();
 
                 // Notify the selection
-                shell.publish((self.on_input)(selection.to_string()));
-                published_message_to_shell = true;
+                shell.publish((self.on_selected)(selection));
 
                 // Unfocus the input
                 let mut local_messages = Vec::new();
@@ -602,14 +761,12 @@ where
             // Focus changed, invalidate widget tree to force a fresh `view`
             shell.invalidate_widgets();
 
-            if !published_message_to_shell {
-                if is_focused {
-                    if let Some(on_open) = self.on_open.take() {
-                        shell.publish(on_open);
-                    }
-                } else if let Some(on_close) = self.on_close.take() {
-                    shell.publish(on_close);
+            if is_focused {
+                if let Some(on_open) = self.on_open.take() {
+                    shell.publish(on_open);
                 }
+            } else if let Some(on_close) = self.on_close.take() {
+                shell.publish(on_close);
             }
         }
     }
@@ -672,9 +829,9 @@ where
                             .downcast_mut::<text_input::State<Renderer::Paragraph>>()
                             .unfocus();
 
-                        (self.on_input)(selection.to_string())
+                        (self.on_selected)(selection)
                     },
-                    None,
+                    self.on_option_hovered.as_deref(),
                     &self.menu_class,
                 )
                 .width(bounds.width)
@@ -710,8 +867,8 @@ where
     Theme: Catalog + 'a,
     Renderer: text::Renderer + 'a,
 {
-    fn from(combo_box: SuggestionTextInput<'a, T, Message, Theme, Renderer>) -> Self {
-        Self::new(combo_box)
+    fn from(suggestion_text_input: SuggestionTextInput<'a, T, Message, Theme, Renderer>) -> Self {
+        Self::new(suggestion_text_input)
     }
 }
 


### PR DESCRIPTION
Moves Traktor menubar entries to a new sidebar.

- fancy icons for starting / restarting server
  - click animation
- sidebar toggle button
  - animation 
  - ALT + C Shortcut
- moved config_window to own module
  - sidebar is part of module
  - bottombar is starting point for #121 
- updated dependencies
  - iced_aw bumped to 0.14.1
  - hide iced/debug behind feature → removed from release builds

closes #158 