### PR TITLE
Add Traktor client connection indicator (#184)

### DIFF
--- a/examples/dummy_traktor_client.rs
+++ b/examples/dummy_traktor_client.rs
@@ -1,0 +1,71 @@
+//! Dummy Traktor client for manually testing the connection indicator
+//! (issue #184).
+//!
+//! A real Traktor client setup holds open a `/cover` WebSocket (that is what
+//! the cover-loader does), and that connection is what the sidebar indicator
+//! counts. This example opens one or more such WebSockets to a running
+//! danceinterpreter server and keeps them open, so the sidebar should light up
+//! green and report the number of connected clients (with the loopback IP).
+//!
+//! Run the app first, enable the server in the sidebar, then:
+//!
+//!     cargo run --example dummy_traktor_client                  # 1 client -> 127.0.0.1:8080
+//!     cargo run --example dummy_traktor_client -- 127.0.0.1:8080 3   # 3 clients
+//!
+//! Press Ctrl-C to disconnect them again.
+
+use futures_util::StreamExt;
+use tokio_tungstenite::connect_async;
+
+#[tokio::main]
+async fn main() {
+    let mut args = std::env::args().skip(1);
+    let addr = args.next().unwrap_or_else(|| "127.0.0.1:8080".to_owned());
+    let count: usize = args.next().and_then(|s| s.parse().ok()).unwrap_or(1);
+
+    let url = format!("ws://{addr}/cover");
+    println!("connecting {count} dummy client(s) to {url} (Ctrl-C to stop)");
+
+    let mut handles = Vec::with_capacity(count);
+    for i in 0..count {
+        let url = url.clone();
+        handles.push(tokio::spawn(async move {
+            match connect_async(&url).await {
+                Ok((mut ws, _)) => {
+                    println!("client {i}: connected");
+
+                    // Hold the socket open. The server pushes cover-file paths
+                    // over it; we just log them. The connection stays alive
+                    // until the process is killed or the server shuts down.
+                    while let Some(msg) = ws.next().await {
+                        match msg {
+                            Ok(msg) => {
+                                if let Ok(text) = msg.to_text()
+                                    && !text.is_empty()
+                                {
+                                    println!("client {i}: server requested cover for {text}");
+                                }
+                            }
+                            Err(e) => {
+                                println!("client {i}: connection error: {e}");
+                                break;
+                            }
+                        }
+                    }
+
+                    println!("client {i}: disconnected");
+                }
+                Err(e) => {
+                    println!(
+                        "client {i}: failed to connect to {url}: {e} \
+                         (is the app running with the server enabled?)"
+                    );
+                }
+            }
+        }));
+    }
+
+    for handle in handles {
+        let _ = handle.await;
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -433,6 +433,9 @@ impl DanceInterpreter {
 
                 TraktorMessage::EnableServer(enabled) => {
                     self.data_provider.traktor_provider.is_enabled = enabled;
+                    if !enabled {
+                        self.data_provider.traktor_provider.clear_clients();
+                    }
                     self.config_window.sidebar.power_button_cache.clear();
                     self.config_window.sidebar.restart_button_cache.clear();
                     ().into()

--- a/src/traktor_api/data_provider.rs
+++ b/src/traktor_api/data_provider.rs
@@ -140,6 +140,12 @@ impl TraktorDataProvider {
         &self.clients
     }
 
+    /// Forget all tracked clients (e.g. when the server is disabled). The live
+    /// list is rebuilt from `ClientsChanged` once the server is running again.
+    pub fn clear_clients(&mut self) {
+        self.clients.clear();
+    }
+
     #[allow(dead_code)]
     pub fn get_log(&self) -> &[String] {
         &self.log

--- a/src/traktor_api/data_provider.rs
+++ b/src/traktor_api/data_provider.rs
@@ -1,7 +1,7 @@
 use crate::dataloading::songinfo::SongInfo;
 use crate::traktor_api::{
-    AppMessage, ChannelState, DeckContentState, DeckState, MixerState, ServerMessage, State,
-    StateUpdate,
+    AppMessage, ChannelState, ClientInfo, DeckContentState, DeckState, MixerState, ServerMessage,
+    State, StateUpdate,
 };
 use iced::futures::channel::mpsc::UnboundedSender;
 use iced::widget::image;
@@ -80,6 +80,7 @@ pub struct TraktorDataProvider {
 
     time_offset_ms: i64,
     pub state: Option<State>,
+    clients: Vec<ClientInfo>,
     covers: HashMap<String, image::Handle>,
 
     sync_x_fader_is_left: bool,
@@ -108,6 +109,7 @@ impl Default for TraktorDataProvider {
 
             time_offset_ms: 0,
             state: None,
+            clients: Vec::new(),
             covers: HashMap::new(),
 
             sync_x_fader_is_left: true,
@@ -126,6 +128,16 @@ impl Default for TraktorDataProvider {
 impl TraktorDataProvider {
     pub fn is_ready(&self) -> bool {
         self.is_enabled && self.channel.as_ref().is_some_and(|c| !c.is_closed())
+    }
+
+    /// Clients currently connected to the running server. Empty when the
+    /// server is not ready (disabled or not yet started).
+    pub fn connected_clients(&self) -> &[ClientInfo] {
+        if !self.is_ready() {
+            return &[];
+        }
+
+        &self.clients
     }
 
     #[allow(dead_code)]
@@ -378,10 +390,14 @@ impl TraktorDataProvider {
 
                 self.time_offset_ms = 0;
                 self.state = None;
+                self.clients.clear();
                 self.sync_x_fader_is_left = true;
                 self.update_song_info(playlist);
 
                 self.reconnect();
+            }
+            ServerMessage::ClientsChanged(clients) => {
+                self.clients = clients;
             }
             ServerMessage::Connect {
                 time_offset_ms,
@@ -475,5 +491,47 @@ impl TraktorDataProvider {
         {
             self.channel = None;
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use iced::futures::channel::mpsc;
+
+    fn client(ip: &str) -> ClientInfo {
+        ClientInfo {
+            addr: Some(format!("{ip}:8080").parse().unwrap()),
+            name: None,
+        }
+    }
+
+    /// `connected_clients()` reflects the latest `ClientsChanged` only while the
+    /// server is ready, and `Ready` clears the list (server restarted).
+    #[test]
+    fn connected_clients_gating_and_reset() {
+        // Keep the receivers alive so the channel counts as "open" (ready).
+        let (tx, _rx) = mpsc::unbounded();
+        let mut provider = TraktorDataProvider {
+            is_enabled: true,
+            channel: Some(tx),
+            ..Default::default()
+        };
+
+        assert!(provider.connected_clients().is_empty());
+
+        provider.process_message(ServerMessage::ClientsChanged(vec![client("1.2.3.4")]), &[]);
+        assert_eq!(provider.connected_clients().len(), 1);
+
+        // Disabling the server hides the list even though it is populated.
+        provider.is_enabled = false;
+        assert!(provider.connected_clients().is_empty());
+        provider.is_enabled = true;
+        assert_eq!(provider.connected_clients().len(), 1);
+
+        // A fresh server start (Ready) resets the tracked clients.
+        let (tx, _rx2) = mpsc::unbounded();
+        provider.process_message(ServerMessage::Ready(tx), &[]);
+        assert!(provider.connected_clients().is_empty());
     }
 }

--- a/src/traktor_api/model.rs
+++ b/src/traktor_api/model.rs
@@ -1,6 +1,7 @@
 use bytes::Bytes;
 use iced::futures::channel::mpsc;
 use serde::{Deserialize, Deserializer, Serialize};
+use std::net::SocketAddr;
 
 #[derive(Debug, Clone)]
 pub enum AppMessage {
@@ -20,6 +21,22 @@ pub enum ServerMessage {
         data: Bytes,
     },
     Log(String),
+    ClientsChanged(Vec<ClientInfo>),
+}
+
+/// Information about a client currently connected to the Traktor server.
+///
+/// A "client" is a live connection on the `/cover` WebSocket — i.e. the
+/// cover-loader that proxies a Traktor instance. It is the only persistent
+/// connection in the API, so it is what we can reliably observe without
+/// changing the client-side protocol.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ClientInfo {
+    /// Remote socket address, if the transport exposed one.
+    pub addr: Option<SocketAddr>,
+    /// Human-readable name, if the client ever reports one. Currently always
+    /// `None` (the protocol carries no name), kept for forward compatibility.
+    pub name: Option<String>,
 }
 
 #[derive(Debug, Copy, Clone)]

--- a/src/traktor_api/server.rs
+++ b/src/traktor_api/server.rs
@@ -35,8 +35,14 @@ struct TraktorServer {
     pending_images: Vec<String>,
 
     cover_socket_id: usize,
-    cover_sockets: HashMap<usize, UnboundedSender<warp::ws::Message>>,
-    client_addrs: HashMap<usize, Option<SocketAddr>>,
+    cover_sockets: HashMap<usize, CoverSocket>,
+}
+
+/// A live `/cover` WebSocket connection: the channel used to push it cover
+/// requests, plus the remote address it connected from (if known).
+struct CoverSocket {
+    sender: UnboundedSender<warp::ws::Message>,
+    addr: Option<SocketAddr>,
 }
 
 impl TraktorServer {
@@ -56,17 +62,22 @@ impl TraktorServer {
 
             cover_socket_id: 0,
             cover_sockets: HashMap::new(),
-            client_addrs: HashMap::new(),
         }
     }
 
     /// Builds the current client list and notifies the app of the change.
     async fn notify_clients_changed(&mut self) {
-        let clients = self
-            .client_addrs
-            .values()
-            .map(|addr| ClientInfo {
-                addr: *addr,
+        // Sort by connection id so the displayed client order stays stable
+        // across renders instead of following HashMap iteration order.
+        let mut sockets: Vec<(&usize, &CoverSocket)> = self.cover_sockets.iter().collect();
+        sockets.sort_by_key(|(id, _)| **id);
+
+        let clients = sockets
+            .into_iter()
+            .map(|(_, socket)| ClientInfo {
+                addr: socket.addr,
+                // TODO: the /cover WebSocket protocol carries no client name.
+                // If a future handshake reports one, populate it here.
                 name: None,
             })
             .collect();
@@ -122,7 +133,7 @@ impl TraktorServer {
 
         for img in new_images {
             for socket in self.cover_sockets.values_mut() {
-                _ = socket.send(warp::ws::Message::text(img)).await;
+                _ = socket.sender.send(warp::ws::Message::text(img)).await;
             }
         }
     }
@@ -224,15 +235,14 @@ impl TraktorServer {
             _ = tx.send(warp::ws::Message::text(img)).await;
         }
 
-        self.cover_sockets.insert(self.cover_socket_id, tx);
-        self.client_addrs.insert(self.cover_socket_id, addr);
+        self.cover_sockets
+            .insert(self.cover_socket_id, CoverSocket { sender: tx, addr });
         self.notify_clients_changed().await;
         self.cover_socket_id
     }
 
     async fn handle_socket_disconnect(&mut self, id: usize) {
         self.cover_sockets.remove(&id);
-        self.client_addrs.remove(&id);
         self.notify_clients_changed().await;
     }
 
@@ -1057,6 +1067,39 @@ mod tests {
             &msg,
             ServerMessage::ClientsChanged(clients) if clients.is_empty()
         ));
+    }
+
+    /// Two concurrently connected sockets are reported as two clients, each
+    /// carrying its own remote address.
+    #[tokio::test]
+    async fn multiple_clients_are_counted() {
+        let (state, mut rx) = new_state();
+        let addr_a: SocketAddr = "1.2.3.4:1111".parse().unwrap();
+        let addr_b: SocketAddr = "5.6.7.8:2222".parse().unwrap();
+
+        let (tx_a, _ws_a) = iced_mpsc::unbounded();
+        state
+            .lock()
+            .await
+            .handle_socket_connect(tx_a, Some(addr_a))
+            .await;
+        let _ = recv_msg(&mut rx).await; // first client
+
+        let (tx_b, _ws_b) = iced_mpsc::unbounded();
+        state
+            .lock()
+            .await
+            .handle_socket_connect(tx_b, Some(addr_b))
+            .await;
+
+        match recv_msg(&mut rx).await {
+            ServerMessage::ClientsChanged(clients) => {
+                assert_eq!(clients.len(), 2);
+                let addrs: Vec<_> = clients.iter().filter_map(|c| c.addr).collect();
+                assert!(addrs.contains(&addr_a) && addrs.contains(&addr_b));
+            }
+            other => panic!("expected ClientsChanged, got {:?}", other),
+        }
     }
 
     // -- /log endpoint --

--- a/src/traktor_api/server.rs
+++ b/src/traktor_api/server.rs
@@ -1,6 +1,6 @@
 use crate::async_utils::DroppingOnce;
 use crate::traktor_api::model::{
-    AppMessage, ConnectionResponse, InitializeRequest, ServerMessage, UpdateRequest,
+    AppMessage, ClientInfo, ConnectionResponse, InitializeRequest, ServerMessage, UpdateRequest,
 };
 use crate::traktor_api::{ID, StateUpdate};
 use bytes::Bytes;
@@ -36,6 +36,7 @@ struct TraktorServer {
 
     cover_socket_id: usize,
     cover_sockets: HashMap<usize, UnboundedSender<warp::ws::Message>>,
+    client_addrs: HashMap<usize, Option<SocketAddr>>,
 }
 
 impl TraktorServer {
@@ -55,7 +56,22 @@ impl TraktorServer {
 
             cover_socket_id: 0,
             cover_sockets: HashMap::new(),
+            client_addrs: HashMap::new(),
         }
+    }
+
+    /// Builds the current client list and notifies the app of the change.
+    async fn notify_clients_changed(&mut self) {
+        let clients = self
+            .client_addrs
+            .values()
+            .map(|addr| ClientInfo {
+                addr: *addr,
+                name: None,
+            })
+            .collect();
+        self.send_message(ServerMessage::ClientsChanged(clients))
+            .await;
     }
 
     async fn send_message(&mut self, message: ServerMessage) {
@@ -195,7 +211,11 @@ impl TraktorServer {
         StatusCode::ACCEPTED
     }
 
-    async fn handle_socket_connect(&mut self, mut tx: UnboundedSender<warp::ws::Message>) -> usize {
+    async fn handle_socket_connect(
+        &mut self,
+        mut tx: UnboundedSender<warp::ws::Message>,
+        addr: Option<SocketAddr>,
+    ) -> usize {
         while self.cover_sockets.contains_key(&self.cover_socket_id) {
             self.cover_socket_id += 1;
         }
@@ -205,11 +225,15 @@ impl TraktorServer {
         }
 
         self.cover_sockets.insert(self.cover_socket_id, tx);
+        self.client_addrs.insert(self.cover_socket_id, addr);
+        self.notify_clients_changed().await;
         self.cover_socket_id
     }
 
-    fn handle_socket_disconnect(&mut self, id: usize) {
+    async fn handle_socket_disconnect(&mut self, id: usize) {
         self.cover_sockets.remove(&id);
+        self.client_addrs.remove(&id);
+        self.notify_clients_changed().await;
     }
 
     async fn handle_log(&mut self, msg: String) -> impl warp::Reply + use<> {
@@ -405,39 +429,42 @@ impl TraktorServer {
     ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
         warp::ws()
             .and(Self::with_state(state))
-            .map(|ws: warp::ws::Ws, state: Arc<Mutex<Self>>| {
-                ws.on_upgrade(move |socket| async move {
-                    let (mut ws_tx, mut ws_rx) = socket.split();
-                    let (tx, mut rx) = iced::futures::channel::mpsc::unbounded();
+            .and(warp::addr::remote())
+            .map(
+                |ws: warp::ws::Ws, state: Arc<Mutex<Self>>, addr: Option<SocketAddr>| {
+                    ws.on_upgrade(move |socket| async move {
+                        let (mut ws_tx, mut ws_rx) = socket.split();
+                        let (tx, mut rx) = iced::futures::channel::mpsc::unbounded();
 
-                    tokio::task::spawn(async move {
-                        while let Some(message) = rx.next().await {
-                            ws_tx
-                                .send(message)
-                                .unwrap_or_else(|e| {
-                                    println!("websocket send error: {}", e);
-                                })
-                                .await;
-                        }
-                    });
-
-                    let socket_id = state.lock().await.handle_socket_connect(tx).await;
-                    println!("websocket connected");
-
-                    while let Some(result) = ws_rx.next().await {
-                        match result {
-                            Ok(_) => {}
-                            Err(e) => {
-                                println!("websocket error: {}", e);
-                                break;
+                        tokio::task::spawn(async move {
+                            while let Some(message) = rx.next().await {
+                                ws_tx
+                                    .send(message)
+                                    .unwrap_or_else(|e| {
+                                        println!("websocket send error: {}", e);
+                                    })
+                                    .await;
                             }
-                        };
-                    }
+                        });
 
-                    state.lock().await.handle_socket_disconnect(socket_id);
-                    println!("websocket disconnected");
-                })
-            })
+                        let socket_id = state.lock().await.handle_socket_connect(tx, addr).await;
+                        println!("websocket connected");
+
+                        while let Some(result) = ws_rx.next().await {
+                            match result {
+                                Ok(_) => {}
+                                Err(e) => {
+                                    println!("websocket error: {}", e);
+                                    break;
+                                }
+                            };
+                        }
+
+                        state.lock().await.handle_socket_disconnect(socket_id).await;
+                        println!("websocket disconnected");
+                    })
+                },
+            )
     }
 
     fn route_log(
@@ -1000,6 +1027,38 @@ mod tests {
         assert_eq!(res.status(), 400);
     }
 
+    // -- client tracking (cover WebSocket connections) --
+
+    /// Connecting a cover socket emits ClientsChanged carrying the remote
+    /// address; disconnecting emits ClientsChanged with the client removed.
+    #[tokio::test]
+    async fn socket_connect_and_disconnect_emit_client_list() {
+        let (state, mut rx) = new_state();
+        let addr: SocketAddr = "1.2.3.4:5678".parse().unwrap();
+
+        let (tx, _ws_rx) = iced_mpsc::unbounded();
+        let id = state
+            .lock()
+            .await
+            .handle_socket_connect(tx, Some(addr))
+            .await;
+
+        let msg = recv_msg(&mut rx).await;
+        assert!(matches!(
+            &msg,
+            ServerMessage::ClientsChanged(clients)
+                if clients.len() == 1 && clients[0].addr == Some(addr)
+        ));
+
+        state.lock().await.handle_socket_disconnect(id).await;
+
+        let msg = recv_msg(&mut rx).await;
+        assert!(matches!(
+            &msg,
+            ServerMessage::ClientsChanged(clients) if clients.is_empty()
+        ));
+    }
+
     // -- /log endpoint --
 
     /// POST /log emits a Log message and returns 201.
@@ -1249,6 +1308,40 @@ mod tests {
                 .expect("WS error");
 
             assert_eq!(ws_msg.into_text().unwrap(), "/music/new_track.mp3");
+        }
+
+        /// Connecting a real cover WebSocket emits ClientsChanged with the
+        /// client's resolved remote address; dropping it emits an empty list.
+        #[tokio::test]
+        async fn cover_websocket_connect_disconnect_tracks_clients() {
+            let mut server = TestServer::start().await;
+
+            let ws_url = format!("ws://{}/cover", server.addr);
+            let (ws_stream, _) = tokio_tungstenite::connect_async(&ws_url)
+                .await
+                .expect("WebSocket connection failed");
+
+            // Connecting reports exactly one client with a known address.
+            match server.recv().await {
+                ServerMessage::ClientsChanged(clients) => {
+                    assert_eq!(clients.len(), 1);
+                    assert!(
+                        clients[0].addr.is_some(),
+                        "remote address should be resolved over TCP"
+                    );
+                }
+                other => panic!("expected ClientsChanged, got {:?}", other),
+            }
+
+            // Dropping the socket eventually reports no clients.
+            drop(ws_stream);
+            loop {
+                match server.recv().await {
+                    ServerMessage::ClientsChanged(clients) if clients.is_empty() => break,
+                    ServerMessage::ClientsChanged(_) => continue,
+                    other => panic!("expected ClientsChanged, got {:?}", other),
+                }
+            }
         }
 
         /// Dropping TestServer aborts the task; a subsequent bind to the same

--- a/src/ui/config_window/sidebar.rs
+++ b/src/ui/config_window/sidebar.rs
@@ -8,8 +8,8 @@ use crate::ui::widget::suggestion_text_input::SuggestionTextInput;
 use crate::ui::widget::{power_button, restart_button, suggestion_text_input};
 use crate::{DanceInterpreter, Message};
 use iced::alignment::Vertical;
-use iced::widget::{Container, canvas, column as col, container, pick_list, row, text};
-use iced::{Alignment, Animation, Length, animation};
+use iced::widget::{Column, Container, canvas, column as col, container, pick_list, row, text};
+use iced::{Alignment, Animation, Length, animation, border};
 use network_interface::Addr::V4;
 use network_interface::{NetworkInterface, NetworkInterfaceConfig};
 use std::time::Duration;
@@ -84,6 +84,7 @@ impl Sidebar {
                     .align_x(Alignment::Center)
                 ]
                 .spacing(10),
+                Self::build_client_status(dance_interpreter),
                 col![
                     text("Server Address: "),
                     self.build_network_interface_combo_box(dance_interpreter)
@@ -146,6 +147,66 @@ impl Sidebar {
             container::Style::default().background(t.extended_palette().background.weakest.color)
         })
         .align_y(Vertical::Top)
+    }
+
+    /// A small LED + label showing whether (and how many) Traktor clients are
+    /// connected, listing each client's name or IP when available.
+    fn build_client_status<'a>(dance_interpreter: &DanceInterpreter) -> Column<'a, Message> {
+        let clients = dance_interpreter
+            .data_provider
+            .traktor_provider
+            .connected_clients();
+        let count = clients.len();
+        let connected = count > 0;
+
+        let led = container(text(""))
+            .width(Length::Fixed(12.0))
+            .height(Length::Fixed(12.0))
+            .style(move |t: &iced::Theme| {
+                let palette = t.extended_palette();
+                let color = if connected {
+                    palette.success.base.color
+                } else {
+                    palette.background.strong.color
+                };
+                container::Style {
+                    background: Some(color.into()),
+                    border: border::rounded(6.0),
+                    ..container::Style::default()
+                }
+            });
+
+        let summary = if connected {
+            format!(
+                "{} Traktor client{} connected",
+                count,
+                if count == 1 { "" } else { "s" }
+            )
+        } else {
+            "No Traktor client connected".to_owned()
+        };
+
+        let mut column = col![
+            row![led, text(summary)]
+                .spacing(8)
+                .align_y(Alignment::Center)
+        ]
+        .spacing(4)
+        .width(Length::Fill)
+        .align_x(Alignment::Center);
+
+        for client in clients {
+            let label = client
+                .name
+                .clone()
+                .or_else(|| client.addr.map(|addr| addr.ip().to_string()));
+
+            if let Some(label) = label {
+                column = column.push(text(label).size(12));
+            }
+        }
+
+        column
     }
 
     fn build_network_interface_combo_box(

--- a/src/ui/config_window/sidebar.rs
+++ b/src/ui/config_window/sidebar.rs
@@ -8,7 +8,9 @@ use crate::ui::widget::suggestion_text_input::SuggestionTextInput;
 use crate::ui::widget::{power_button, restart_button, suggestion_text_input};
 use crate::{DanceInterpreter, Message};
 use iced::alignment::Vertical;
-use iced::widget::{Column, Container, canvas, column as col, container, pick_list, row, text};
+use iced::widget::{
+    Column, Container, Space, canvas, column as col, container, pick_list, row, text,
+};
 use iced::{Alignment, Animation, Length, animation, border};
 use network_interface::Addr::V4;
 use network_interface::{NetworkInterface, NetworkInterfaceConfig};
@@ -159,7 +161,7 @@ impl Sidebar {
         let count = clients.len();
         let connected = count > 0;
 
-        let led = container(text(""))
+        let led = container(Space::new())
             .width(Length::Fixed(12.0))
             .height(Length::Fixed(12.0))
             .style(move |t: &iced::Theme| {


### PR DESCRIPTION
Closes #184.

Adds a connection indicator to the server settings sidebar showing **whether and how many Traktor clients are connected**, with each client's IP (and name, should the protocol ever provide one). No "server running" indicator — that stays with the power button.

## How presence is detected
Connection state is derived from live `/cover` **WebSocket** connections — the only persistent connection in the existing protocol (opened by the cover-loader, i.e. the standard Traktor → cover-loader → server path). This means **no client-side API change** is required.

HTTP request activity was deliberately *not* used as a presence signal: the QML `ApiClient` is stateless with no heartbeat, and per `ApiDeck.qml` a steadily-playing deck sends no requests for minutes (position is extrapolated client-side), so a timeout-based approach would falsely flip to "disconnected" mid-set.

Trade-off: a setup running the QML client *without* the cover-loader has no WebSocket and so reads 0 — but that is the non-standard configuration.

## Changes
- **model**: `ClientInfo` + `ServerMessage::ClientsChanged`
- **server**: track per-socket remote addresses (`warp::addr::remote()`), emit on connect/disconnect
- **data_provider**: store clients, reset on `Ready`, expose `connected_clients()` (gated on the server being ready)
- **sidebar**: LED + label + per-client IP/name list
- **examples**: `dummy_traktor_client` for manual testing

## Testing
- `cargo test` — 25 pass, `cargo clippy` clean (apart from a pre-existing unused-import warning in `main.rs`).
- New tests:
  - `socket_connect_and_disconnect_emit_client_list` (server, unit)
  - `cover_websocket_connect_disconnect_tracks_clients` (server, integration / real TCP — also verifies the remote address resolves)
  - `connected_clients_gating_and_reset` (data_provider, unit — gating + reset behaviour)
- Manual: run the app, enable the server, then `cargo run --example dummy_traktor_client -- 127.0.0.1:8080 3` and watch the indicator. Ctrl-C disconnects them.

Note: the rendered LED was not visually verified in CI (headless), but the connect/disconnect wiring is covered by the integration test.