### PR TITLE
Tooltips on UI buttons (#181)

### DIFF
--- a/src/ui/config_window/bottombar.rs
+++ b/src/ui/config_window/bottombar.rs
@@ -1,4 +1,5 @@
 use crate::dataloading::dataprovider::song_data_provider::SongChange;
+use crate::ui::with_tooltip;
 use crate::{DanceInterpreter, Message};
 use iced::alignment::{Horizontal, Vertical};
 use iced::widget::scrollable::{Direction, Scrollbar};
@@ -46,13 +47,15 @@ pub(crate) fn get_statics_buttons(
         .iter()
         .enumerate()
         .map(|(idx, s)| {
-            button(text(&s.dance).font(bold_font))
-                .style(button::secondary)
-                .on_press(Message::SongChanged(SongChange::StaticAbsolute(idx)))
-                .into()
+            with_tooltip(
+                button(text(&s.dance).font(bold_font))
+                    .style(button::secondary)
+                    .on_press(Message::SongChanged(SongChange::StaticAbsolute(idx))),
+                format!("Show {} static", s.dance),
+            )
         })
         .collect();
-    statics.insert(0, btn_blank.into());
-    statics.insert(1, btn_traktor.into());
+    statics.insert(0, with_tooltip(btn_blank, "Show blank screen"));
+    statics.insert(1, with_tooltip(btn_traktor, "Show current Traktor song"));
     statics
 }

--- a/src/ui/config_window/mod.rs
+++ b/src/ui/config_window/mod.rs
@@ -7,7 +7,7 @@ use crate::dataloading::dataprovider::song_data_provider::{
 };
 use crate::ui::config_window::sidebar::Sidebar;
 use crate::ui::widget::dynamic_text_input::DynamicTextInput;
-use crate::ui::{material_icon, material_icon_sized};
+use crate::ui::{material_icon, material_icon_sized, with_tooltip};
 use crate::{DanceInterpreter, Message, Window};
 use iced::alignment::Vertical;
 use iced::widget::{
@@ -141,17 +141,26 @@ impl ConfigWindow {
                     .on_change(move |v| Message::SongDataEdit(i, SongDataEdit::Dance(v))),
                 row![
                     Space::new().width(Length::Fill).height(Length::Shrink),
-                    material_icon_message_button(
-                        "smart_display",
-                        Message::SongChanged(SongChange::PlaylistAbsolute(i))
+                    with_tooltip(
+                        material_icon_message_button(
+                            "smart_display",
+                            Message::SongChanged(SongChange::PlaylistAbsolute(i))
+                        ),
+                        "Play now"
                     ),
-                    material_icon_message_button(
-                        "queue_play_next",
-                        Message::SetNextSong(SongDataSource::Playlist(i))
+                    with_tooltip(
+                        material_icon_message_button(
+                            "queue_play_next",
+                            Message::SetNextSong(SongDataSource::Playlist(i))
+                        ),
+                        "Set as next song"
                     ),
-                    material_icon_message_button(
-                        "delete",
-                        Message::DeleteSong(SongDataSource::Playlist(i))
+                    with_tooltip(
+                        material_icon_message_button(
+                            "delete",
+                            Message::DeleteSong(SongDataSource::Playlist(i))
+                        ),
+                        "Delete song"
                     ),
                 ]
                 .spacing(5)

--- a/src/ui/config_window/mod.rs
+++ b/src/ui/config_window/mod.rs
@@ -146,7 +146,7 @@ impl ConfigWindow {
                             "smart_display",
                             Message::SongChanged(SongChange::PlaylistAbsolute(i))
                         ),
-                        "Play now"
+                        "Show now"
                     ),
                     with_tooltip(
                         material_icon_message_button(

--- a/src/ui/config_window/sidebar.rs
+++ b/src/ui/config_window/sidebar.rs
@@ -6,6 +6,7 @@ use crate::ui::config_window::labeled_message_toggler;
 use crate::ui::widget::canvas_toggle::CanvasToggle;
 use crate::ui::widget::suggestion_text_input::SuggestionTextInput;
 use crate::ui::widget::{power_button, restart_button, suggestion_text_input};
+use crate::ui::with_tooltip;
 use crate::{DanceInterpreter, Message};
 use iced::alignment::Vertical;
 use iced::widget::{Container, canvas, column as col, container, pick_list, row, text};
@@ -63,22 +64,28 @@ impl Sidebar {
                 text("Server Settings").size(24),
                 row![
                     col![
-                        CanvasToggle::new(
-                            dance_interpreter.data_provider.traktor_provider.is_enabled,
-                            &self.power_button_cache
-                        )
-                        .on_toggle(|b| Message::Traktor(TraktorMessage::EnableServer(b)))
-                        .on_draw(power_button::draw),
+                        with_tooltip(
+                            CanvasToggle::new(
+                                dance_interpreter.data_provider.traktor_provider.is_enabled,
+                                &self.power_button_cache
+                            )
+                            .on_toggle(|b| Message::Traktor(TraktorMessage::EnableServer(b)))
+                            .on_draw(power_button::draw),
+                            "Enable / disable Traktor server"
+                        ),
                         text("Enable Server")
                     ]
                     .align_x(Alignment::Center),
                     col![
-                        CanvasToggle::new(
-                            dance_interpreter.data_provider.traktor_provider.is_enabled,
-                            &self.restart_button_cache
-                        )
-                        .on_toggle(|_| Message::Traktor(TraktorMessage::Reconnect))
-                        .on_draw(restart_button::draw),
+                        with_tooltip(
+                            CanvasToggle::new(
+                                dance_interpreter.data_provider.traktor_provider.is_enabled,
+                                &self.restart_button_cache
+                            )
+                            .on_toggle(|_| Message::Traktor(TraktorMessage::Reconnect))
+                            .on_draw(restart_button::draw),
+                            "Restart Traktor server"
+                        ),
                         text("Restart Server")
                     ]
                     .align_x(Alignment::Center)

--- a/src/ui/config_window/sidebar.rs
+++ b/src/ui/config_window/sidebar.rs
@@ -71,7 +71,7 @@ impl Sidebar {
                             )
                             .on_toggle(|b| Message::Traktor(TraktorMessage::EnableServer(b)))
                             .on_draw(power_button::draw),
-                            "Enable / disable Traktor server"
+                            "Toggle Traktor Server"
                         ),
                         text("Enable Server")
                     ]
@@ -84,7 +84,7 @@ impl Sidebar {
                             )
                             .on_toggle(|_| Message::Traktor(TraktorMessage::Reconnect))
                             .on_draw(restart_button::draw),
-                            "Restart Traktor server"
+                            "Restart Traktor Server"
                         ),
                         text("Restart Server")
                     ]

--- a/src/ui/config_window/top_bar.rs
+++ b/src/ui/config_window/top_bar.rs
@@ -3,6 +3,7 @@ use crate::ui::config_window::{
     ConfigWindow, label_message_button_fill, label_message_button_fill_opt,
     label_message_button_shrink, labeled_message_checkbox, material_icon_sized_message_button,
 };
+use crate::ui::with_tooltip;
 use crate::{DanceInterpreter, Message};
 use iced::alignment::Vertical;
 use iced::border::Radius;
@@ -113,23 +114,26 @@ pub(crate) fn build<'a>(
 
     let view_buttons = row![
         Space::new().width(Length::Fill),
-        playlist_button,
-        statics_button,
+        with_tooltip(playlist_button, "Show playlist view"),
+        with_tooltip(statics_button, "Show statics view"),
         Space::new().width(Length::Fill)
     ]
     .width(Length::Fill)
     .spacing(5);
 
-    let sidebar_button = material_icon_sized_message_button(
-        if config_window.sidebar.state.value() {
-            "right_panel_close"
-        } else {
-            "right_panel_open"
-        },
-        20.0,
-        Message::Sidebar(SidebarMessage::Toggle),
-    )
-    .padding([0, 4]);
+    let sidebar_button = with_tooltip(
+        material_icon_sized_message_button(
+            if config_window.sidebar.state.value() {
+                "right_panel_close"
+            } else {
+                "right_panel_open"
+            },
+            20.0,
+            Message::Sidebar(SidebarMessage::Toggle),
+        )
+        .padding([0, 4]),
+        "Toggle settings panel",
+    );
 
     stack![
         row![mb, horizontal()].width(Length::Fill),

--- a/src/ui/config_window/top_bar.rs
+++ b/src/ui/config_window/top_bar.rs
@@ -114,8 +114,8 @@ pub(crate) fn build<'a>(
 
     let view_buttons = row![
         Space::new().width(Length::Fill),
-        with_tooltip(playlist_button, "Show playlist view"),
-        with_tooltip(statics_button, "Show statics view"),
+        with_tooltip(playlist_button, "Show Playlist"),
+        with_tooltip(statics_button, "Show Statics"),
         Space::new().width(Length::Fill)
     ]
     .width(Length::Fill)
@@ -132,7 +132,11 @@ pub(crate) fn build<'a>(
             Message::Sidebar(SidebarMessage::Toggle),
         )
         .padding([0, 4]),
-        "Toggle settings panel",
+        if config_window.sidebar.state.value() {
+            "Expand Traktor Panel"
+        } else {
+            "Collapse Traktor Panel"
+        },
     );
 
     stack![

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -1,10 +1,29 @@
 use iced::widget::Text;
 use iced::widget::text::Shaping;
-use iced::{Font, Length, Pixels, Renderer, Theme};
+use iced::widget::{container, text, tooltip};
+use iced::{Element, Font, Length, Pixels, Renderer, Theme};
 
 pub mod config_window;
 pub mod song_window;
 pub mod widget;
+
+/// Wraps a widget in a tooltip with a readable styled container.
+pub fn with_tooltip<'a, Message: 'a>(
+    content: impl Into<Element<'a, Message>>,
+    label: impl text::IntoFragment<'a>,
+) -> Element<'a, Message> {
+    tooltip(
+        content,
+        container(text(label)).padding([4, 8]).style(|t: &Theme| {
+            container::Style::default()
+                .background(t.extended_palette().background.strong.color)
+                .border(iced::border::rounded(4))
+        }),
+        tooltip::Position::Bottom,
+    )
+    .gap(4)
+    .into()
+}
 
 pub fn material_icon_sized(id: &'_ str, size: impl Into<Pixels>) -> Text<'_, Theme, Renderer> {
     Text::new(id)


### PR DESCRIPTION
Implements #181.

Adds explanatory tooltips to nearly all buttons in the UI.

## Changes
- New centralized `with_tooltip(content, label)` helper in `ui/mod.rs` (styled container, bottom position).
- Tooltips applied to:
  - Playlist row icons: Play now / Set as next song / Delete song
  - Sidebar: Enable/disable Traktor server, Restart Traktor server
  - Top bar: Toggle settings panel, Show playlist view, Show statics view
  - Bottom bar: Show blank screen, Show current Traktor song, and per-dance "Show {dance} static"

## Notes
Top-bar dropdown menu items (File/Edit/SongWindow) were intentionally left untooltipped — they fall in the optional bucket and the `iced_aw` menu layout makes them awkward to wrap.

Closes #181.