### PR TITLE
Delete confirmation dialog and undo (#182)

### DIFF
--- a/src/dataloading/dataprovider/song_data_provider.rs
+++ b/src/dataloading/dataprovider/song_data_provider.rs
@@ -149,7 +149,7 @@ impl SongDataProvider {
             return;
         };
 
-        if current_index == self.playlist_songs.len() - 1 {
+        if current_index == self.playlist_songs.len().saturating_sub(1) {
             return;
         }
 

--- a/src/dataloading/dataprovider/song_data_provider.rs
+++ b/src/dataloading/dataprovider/song_data_provider.rs
@@ -29,6 +29,21 @@ pub enum SongDataEdit {
     Dance(String),
 }
 
+/// Data captured when a song is deleted, enough to restore it at its
+/// original position for undo.
+#[derive(Debug, Clone)]
+pub enum RemovedSong {
+    Playlist {
+        index: usize,
+        song: SongInfo,
+        played: bool,
+    },
+    Static {
+        index: usize,
+        song: SongInfo,
+    },
+}
+
 #[derive(Default)]
 pub struct SongDataProvider {
     pub playlist_songs: Vec<SongInfo>,
@@ -170,12 +185,55 @@ impl SongDataProvider {
     }
 
     pub fn delete_song(&mut self, song: SongDataSource) {
-        if let SongDataSource::Playlist(i) = song {
-            self.playlist_songs.remove(i);
-            self.playlist_played.remove(i);
-        } else if let SongDataSource::Static(i) = song {
-            self.statics.remove(i);
+        self.delete_song_returning(song);
+    }
+
+    /// Deletes the referenced song and returns the removed data so the
+    /// caller can offer an undo. Returns `None` if the index is out of range.
+    pub fn delete_song_returning(&mut self, song: SongDataSource) -> Option<RemovedSong> {
+        match song {
+            SongDataSource::Playlist(i) => {
+                if i >= self.playlist_songs.len() {
+                    return None;
+                }
+                let song = self.playlist_songs.remove(i);
+                let played = if i < self.playlist_played.len() {
+                    self.playlist_played.remove(i)
+                } else {
+                    false
+                };
+                Some(RemovedSong::Playlist {
+                    index: i,
+                    song,
+                    played,
+                })
+            }
+            SongDataSource::Static(i) => {
+                if i >= self.statics.len() {
+                    return None;
+                }
+                let song = self.statics.remove(i);
+                Some(RemovedSong::Static { index: i, song })
+            }
+            _ => None,
         }
+    }
+
+    /// Re-inserts a previously removed playlist song at the given index,
+    /// clamping to the end if the index is out of range.
+    pub fn insert_song_at(&mut self, index: usize, song: SongInfo, played: bool) {
+        let index = index.min(self.playlist_songs.len());
+        self.playlist_songs.insert(index, song);
+
+        let played_index = index.min(self.playlist_played.len());
+        self.playlist_played.insert(played_index, played);
+    }
+
+    /// Re-inserts a previously removed static song at the given index,
+    /// clamping to the end if the index is out of range.
+    pub fn insert_static_at(&mut self, index: usize, song: SongInfo) {
+        let index = index.min(self.statics.len());
+        self.statics.insert(index, song);
     }
 
     pub fn handle_song_change(&mut self, change: SongChange) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ mod ui;
 
 use crate::async_utils::run_subscription_with;
 use crate::dataloading::dataprovider::song_data_provider::{
-    SongChange, SongDataEdit, SongDataProvider, SongDataSource,
+    RemovedSong, SongChange, SongDataEdit, SongDataProvider, SongDataSource,
 };
 use crate::dataloading::id3tagreader::read_song_info_from_filepath;
 use crate::dataloading::m3uloader::load_tag_data_from_m3u;
@@ -75,6 +75,10 @@ pub enum Message {
     ReloadStatics,
     AddSong(SongInfo),
     DeleteSong(SongDataSource),
+    RequestDeleteSong(SongDataSource),
+    ConfirmDelete,
+    CancelDelete,
+    UndoDelete,
     ScrollBy(f32),
     SnapTo(RelativeOffset),
     ToggleStaticsView,
@@ -357,6 +361,43 @@ impl DanceInterpreter {
                 ().into()
             }
 
+            Message::RequestDeleteSong(song) => {
+                self.config_window.pending_delete = Some(song);
+                ().into()
+            }
+
+            Message::ConfirmDelete => {
+                if let Some(song) = self.config_window.pending_delete.take()
+                    && let Some(removed) = self.data_provider.delete_song_returning(song)
+                {
+                    self.config_window.last_deleted = Some(removed);
+                }
+                ().into()
+            }
+
+            Message::CancelDelete => {
+                self.config_window.pending_delete = None;
+                ().into()
+            }
+
+            Message::UndoDelete => {
+                if let Some(removed) = self.config_window.last_deleted.take() {
+                    match removed {
+                        RemovedSong::Playlist {
+                            index,
+                            song,
+                            played,
+                        } => {
+                            self.data_provider.insert_song_at(index, song, played);
+                        }
+                        RemovedSong::Static { index, song } => {
+                            self.data_provider.insert_static_at(index, song);
+                        }
+                    }
+                }
+                ().into()
+            }
+
             Message::SetNextSong(i) => {
                 self.data_provider.set_next(i);
                 ().into()
@@ -599,6 +640,7 @@ impl DanceInterpreter {
                         Some(Message::AddBlankSong(RelativeOffset::END))
                     }
                     (Key::Character("r"), Modifiers::CTRL) => Some(Message::ReloadStatics),
+                    (Key::Character("z"), Modifiers::CTRL) => Some(Message::UndoDelete),
                     (Key::Character("c"), Modifiers::ALT) => {
                         Some(Message::Sidebar(SidebarMessage::Toggle))
                     }

--- a/src/ui/config_window/mod.rs
+++ b/src/ui/config_window/mod.rs
@@ -3,18 +3,19 @@ pub mod sidebar;
 pub mod top_bar;
 
 use crate::dataloading::dataprovider::song_data_provider::{
-    SongChange, SongDataEdit, SongDataSource,
+    RemovedSong, SongChange, SongDataEdit, SongDataSource,
 };
+use crate::dataloading::songinfo::SongInfo;
 use crate::ui::config_window::sidebar::Sidebar;
 use crate::ui::widget::dynamic_text_input::DynamicTextInput;
 use crate::ui::{material_icon, material_icon_sized};
 use crate::{DanceInterpreter, Message, Window};
 use iced::alignment::Vertical;
 use iced::widget::{
-    Button, Column, Row, Scrollable, Space, button, checkbox, column as col, container, radio, row,
-    scrollable, text, toggler,
+    Button, Column, Row, Scrollable, Space, button, checkbox, column as col, container, mouse_area,
+    opaque, radio, row, scrollable, stack, text, toggler,
 };
-use iced::{Alignment, Element, Length, Pixels, Renderer, Size, Theme, window};
+use iced::{Alignment, Color, Element, Length, Pixels, Renderer, Size, Theme, window};
 use iced_aw::iced_aw_font;
 use std::sync::LazyLock;
 use std::time::Instant;
@@ -28,6 +29,10 @@ pub struct ConfigWindow {
     pub is_statics_view: bool,
     pub theme: Theme,
     pub follow_system_theme: bool,
+    /// Set while a delete confirmation dialog is open.
+    pub pending_delete: Option<SongDataSource>,
+    /// Most recently deleted song, available for undo.
+    pub last_deleted: Option<RemovedSong>,
 }
 
 pub static PLAYLIST_SCROLLABLE_ID: LazyLock<iced::widget::Id> =
@@ -45,6 +50,8 @@ impl Window for ConfigWindow {
             is_statics_view: false,
             theme: Theme::Dark,
             follow_system_theme: true,
+            pending_delete: None,
+            last_deleted: None,
         }
     }
 
@@ -81,9 +88,68 @@ impl ConfigWindow {
             ));
         let bottom_bar = bottombar::build(dance_interpreter);
 
-        col![row![col![top_bar, content_view], side_bar], bottom_bar]
-            .spacing(5)
-            .into()
+        let base: Element<'a, Message> =
+            col![row![col![top_bar, content_view], side_bar], bottom_bar]
+                .spacing(5)
+                .into();
+
+        if let Some(source) = self.pending_delete.as_ref() {
+            let title = delete_target_label(source, dance_interpreter);
+            stack![base, self.build_delete_dialog(title)].into()
+        } else {
+            base
+        }
+    }
+
+    fn build_delete_dialog<'a>(&'a self, target: String) -> Element<'a, Message> {
+        let card = container(
+            col![
+                text("Delete song?").size(20),
+                text(target),
+                row![
+                    label_message_button("Cancel", Message::CancelDelete).width(Length::Fill),
+                    button(text("Delete").align_x(Alignment::Center))
+                        .padding([4, 8])
+                        .style(button::danger)
+                        .on_press(Message::ConfirmDelete)
+                        .width(Length::Fill),
+                ]
+                .spacing(10),
+            ]
+            .spacing(15)
+            .width(Length::Fixed(360.0)),
+        )
+        .padding(20)
+        .style(|t: &Theme| {
+            let palette = t.extended_palette();
+            container::Style::default()
+                .background(palette.background.base.color)
+                .border(iced::Border {
+                    color: palette.background.strong.color,
+                    width: 1.0,
+                    radius: 8.0.into(),
+                })
+        });
+
+        let backdrop = mouse_area(
+            container(Space::new().width(Length::Fill).height(Length::Fill))
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .style(|_t: &Theme| {
+                    container::Style::default().background(Color::from_rgba(0.0, 0.0, 0.0, 0.5))
+                }),
+        )
+        .on_press(Message::CancelDelete);
+
+        let centered_card = container(card)
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .align_x(Alignment::Center)
+            .align_y(Alignment::Center);
+
+        // The backdrop captures clicks for dismissal; the card sits on top and
+        // intercepts its own clicks so they don't fall through to the backdrop.
+        opaque(stack![backdrop, opaque(centered_card)])
     }
 
     fn build_playlist_view(&'_ self, dance_interpreter: &DanceInterpreter) -> Column<'_, Message> {
@@ -151,7 +217,7 @@ impl ConfigWindow {
                     ),
                     material_icon_message_button(
                         "delete",
-                        Message::DeleteSong(SongDataSource::Playlist(i))
+                        Message::RequestDeleteSong(SongDataSource::Playlist(i))
                     ),
                 ]
                 .spacing(5)
@@ -182,11 +248,74 @@ impl ConfigWindow {
             .spacing(5)
             .id(PLAYLIST_SCROLLABLE_ID.clone());
 
-        col!(trow, playlist_scrollable).spacing(5)
+        let mut view: Column<'_, Message> = col!().spacing(5);
+
+        if let Some(removed) = self.last_deleted.as_ref() {
+            view = view.push(self.build_undo_bar(removed));
+        }
+
+        view.push(trow).push(playlist_scrollable)
+    }
+
+    fn build_undo_bar<'a>(&'a self, removed: &'a RemovedSong) -> Element<'a, Message> {
+        let song = match removed {
+            RemovedSong::Playlist { song, .. } => song,
+            RemovedSong::Static { song, .. } => song,
+        };
+
+        let label = format!("Deleted '{}'", removed_song_label(song));
+
+        container(
+            row![
+                text(label).width(Length::Fill).align_y(Vertical::Center),
+                label_message_button_shrink("Undo", Message::UndoDelete),
+            ]
+            .spacing(10)
+            .align_y(Alignment::Center),
+        )
+        .padding([6, 10])
+        .width(Length::Fill)
+        .style(|t: &Theme| {
+            container::Style::default().background(t.extended_palette().background.weak.color)
+        })
+        .into()
     }
 
     fn build_statics_view(&'_ self, _dance_interpreter: &DanceInterpreter) -> Column<'_, Message> {
         col![].width(Length::Fill).height(Length::Fill)
+    }
+}
+
+/// Builds a human-readable label for the song targeted by a delete request,
+/// used in the confirmation dialog.
+fn delete_target_label(source: &SongDataSource, dance_interpreter: &DanceInterpreter) -> String {
+    let song = match source {
+        SongDataSource::Playlist(i) => dance_interpreter.data_provider.playlist_songs.get(*i),
+        SongDataSource::Static(i) => dance_interpreter.data_provider.statics.get(*i),
+        _ => None,
+    };
+
+    match song {
+        Some(song) => removed_song_label(song),
+        None => "this item".to_string(),
+    }
+}
+
+/// Produces a short description of a song for dialog/undo text, preferring
+/// title + artist, then dance, then a generic fallback.
+fn removed_song_label(song: &SongInfo) -> String {
+    let title = song.title.trim();
+    let artist = song.artist.trim();
+    let dance = song.dance.trim();
+
+    if !title.is_empty() && !artist.is_empty() {
+        format!("{} - {}", title, artist)
+    } else if !title.is_empty() {
+        title.to_string()
+    } else if !dance.is_empty() {
+        dance.to_string()
+    } else {
+        "Untitled song".to_string()
     }
 }
 


### PR DESCRIPTION
Implements #182.

Adds **both** a confirmation dialog before deletion **and** an undo afterward, for playlist items (data layer also supports statics symmetrically).

## Changes
- **Confirmation dialog:** clicking a row's delete button opens a modal (proper `opaque`/`mouse_area` overlay). It names the song and offers Cancel / Delete; deletion happens only on confirm. Clicking the backdrop or Cancel dismisses.
- **Undo:** after a confirmed delete the removed item is stashed; an undo bar ("Deleted 'X' — Undo") appears above the playlist and `Ctrl+Z` also triggers undo. Restores the item at its original index. A new delete replaces the stash.
- **Data layer:** `delete_song_returning`, `insert_song_at`, `insert_static_at` (all bounds-checked), plus a `RemovedSong` type capturing index + song + played flag.
- New messages: `RequestDeleteSong`, `ConfirmDelete`, `CancelDelete`, `UndoDelete`.

## Notes
The statics view currently has no delete button, so the dialog/undo UI is wired on playlist rows; the data layer handles statics for symmetry.

Closes #182.