### PR TITLE
[FEAT]: traktor connection indicator (#184)

### DIFF
--- a/examples/traktor_client.rs
+++ b/examples/traktor_client.rs
@@ -1,0 +1,47 @@
+//! Dummy Traktor client for manually testing ui elements like the connection indicator
+//!
+//! Run the app first, enable the server in the sidebar, then:
+//!     cargo run --example dummy_traktor_client                  # 127.0.0.1:8080
+
+use tokio_tungstenite::tungstenite::connect;
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let addr = args.next().unwrap_or_else(|| "127.0.0.1:8080".to_owned());
+
+    let url = format!("ws://{addr}/cover");
+    println!("connecting dummy client to {url} (Ctrl-C to stop)");
+
+    match connect(&url) {
+        Ok((mut ws, _)) => {
+            println!("client connected");
+
+            loop {
+                let msg = ws.read();
+                match msg {
+                    Ok(msg) => {
+                        if let Ok(text) = msg.to_text()
+                            && !text.is_empty()
+                        {
+                            println!("client: server requested cover for {text}");
+                        } else {
+                            println!("client: received non-text message: {msg}");
+                        }
+                    }
+                    Err(e) => {
+                        println!("client: connection error: {e}");
+                        break;
+                    }
+                }
+            }
+
+            println!("client: disconnected");
+        }
+        Err(e) => {
+            println!(
+                "client: failed to connect to {url}: {e} \
+                         (is the app running with the server enabled?)"
+            );
+        }
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -508,7 +508,7 @@ impl DanceInterpreter {
             .traktor_provider
             .state
             .as_ref()
-            .map(|s| s.mixer.clone())
+            .map(|s| s.mixer)
         {
             self.data_provider
                 .process_traktor_message(ServerMessage::Update(StateUpdate::Mixer(mixer_state)));

--- a/src/main.rs
+++ b/src/main.rs
@@ -441,7 +441,7 @@ impl DanceInterpreter {
                 }
 
                 TraktorMessage::EnableServer(enabled) => {
-                    self.data_provider.traktor_provider.is_enabled = enabled;
+                    self.data_provider.traktor_provider.set_enabled(enabled);
                     ().into()
                 }
 

--- a/src/traktor_api/data_provider.rs
+++ b/src/traktor_api/data_provider.rs
@@ -518,11 +518,14 @@ impl TraktorDataProvider {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::traktor_api::DeckPlayState;
     use iced::futures::channel::mpsc;
+    use std::array;
 
-    /// After receiving a ClientChanged message, the provider should be in the CoverLoader state.
+    /// After receiving a [ClientChanged](ServerMessage::ClientChanged) message with a [SockedAddr](SocketAddr), the provider should be in the [CoverLoader](ConnectionState::CoverLoader) state.
+    /// After receiving a [ClientChanged](ServerMessage::ClientChanged) message without a [SockedAddr](SocketAddr), the provider should return to the [Disconnected](ConnectionState::Disconnected) state.
     #[test]
-    fn connecting_cover_loader_and_trakor_sets_connection_state() {
+    fn connecting_cover_loader_sets_connection_state() {
         // Keep the receivers alive so the channel counts as "open" (ready).
         let (tx, _rx) = mpsc::unbounded();
         let mut provider = TraktorDataProvider {
@@ -544,5 +547,132 @@ mod tests {
             provider.get_connection_state(),
             ConnectionState::CoverLoader
         ));
+
+        provider.process_message(ServerMessage::ClientChanged(None), &[]);
+        assert!(matches!(
+            provider.get_connection_state(),
+            ConnectionState::Disconnected
+        ));
+    }
+
+    /// After receiving a [Connect](ServerMessage::Connect) message, the provider should be in the [Traktor](ConnectionState::Traktor) state.
+    #[test]
+    fn connecting_traktor_sets_connection_state() {
+        // Keep the receivers alive so the channel counts as "open" (ready).
+        let (tx, _rx) = mpsc::unbounded();
+        let mut provider = TraktorDataProvider {
+            enabled: true,
+            channel: Some(tx),
+            ..Default::default()
+        };
+
+        assert!(matches!(
+            provider.get_connection_state(),
+            ConnectionState::Disconnected
+        ));
+
+        let connect_message = ServerMessage::Connect {
+            time_offset_ms: 0,
+            initial_state: Box::new(get_sample_state()),
+        };
+
+        provider.process_message(connect_message, &[]);
+        assert!(matches!(
+            provider.get_connection_state(),
+            ConnectionState::Traktor
+        ));
+    }
+
+    /// After receiving a [ClientChanged](ServerMessage::ClientChanged) message with a [SockedAddr](SocketAddr), the provider should be in the [CoverLoader](ConnectionState::CoverLoader) state.
+    /// After receiving a [Connect](ServerMessage::Connect) message, the provider should be in the [Connected](ConnectionState::Connected) state.
+    /// After receiving a [ClientChanged](ServerMessage::ClientChanged) message without a [SockedAddr](SocketAddr), the provider should return to the [Traktor](ConnectionState::Traktor) state.
+    #[test]
+    fn connecting_cover_loader_and_traktor_sets_connection_state() {
+        // Keep the receivers alive so the channel counts as "open" (ready).
+        let (tx, _rx) = mpsc::unbounded();
+        let mut provider = TraktorDataProvider {
+            enabled: true,
+            channel: Some(tx),
+            ..Default::default()
+        };
+
+        assert!(matches!(
+            provider.get_connection_state(),
+            ConnectionState::Disconnected
+        ));
+
+        provider.process_message(
+            ServerMessage::ClientChanged(Some("127.0.0.1:8080".parse().unwrap())),
+            &[],
+        );
+        assert!(matches!(
+            provider.get_connection_state(),
+            ConnectionState::CoverLoader
+        ));
+
+        let connect_message = ServerMessage::Connect {
+            time_offset_ms: 0,
+            initial_state: Box::new(get_sample_state()),
+        };
+
+        provider.process_message(connect_message, &[]);
+        assert!(matches!(
+            provider.get_connection_state(),
+            ConnectionState::Connected
+        ));
+
+        provider.process_message(ServerMessage::ClientChanged(None), &[]);
+        assert!(matches!(
+            provider.get_connection_state(),
+            ConnectionState::Traktor
+        ));
+
+        provider.set_enabled(false);
+
+        assert!(matches!(
+            provider.get_connection_state(),
+            ConnectionState::Disconnected
+        ));
+    }
+
+    fn get_sample_state() -> State {
+        let deck_state = DeckState {
+            content: DeckContentState {
+                is_loaded: false,
+                number: 0,
+                title: "".to_string(),
+                artist: "".to_string(),
+                album: "".to_string(),
+                genre: "".to_string(),
+                comment: "".to_string(),
+                comment2: "".to_string(),
+                label: "".to_string(),
+                key: "".to_string(),
+                file_path: "".to_string(),
+                track_length: 0.0,
+                bpm: 0.0,
+            },
+            play_state: DeckPlayState {
+                timestamp: 0,
+                position: 0.0,
+                speed: 0.0,
+            },
+        };
+        State {
+            mixer: MixerState {
+                x_fader: 0.0,
+                master_volume: 0.0,
+                cue_volume: 0.0,
+                cue_mix: 0.0,
+                mic_volume: 0.0,
+            },
+            channels: [ChannelState {
+                cue: false,
+                volume: 0.0,
+                x_fader_left: false,
+                x_fader_right: false,
+            }; 4],
+            decks: array::from_fn(|_| deck_state.clone()),
+        }
     }
 }

--- a/src/traktor_api/data_provider.rs
+++ b/src/traktor_api/data_provider.rs
@@ -66,6 +66,14 @@ pub enum TraktorMessage {
     Reconnect,
 }
 
+#[derive(Debug, Clone, Copy)]
+pub enum ConnectionState {
+    Disconnected,
+    CoverLoader,
+    Traktor,
+    Connected,
+}
+
 pub struct TraktorDataProvider {
     pub address: String,
     pub submitted_address: String,
@@ -81,6 +89,7 @@ pub struct TraktorDataProvider {
     time_offset_ms: i64,
     pub state: Option<State>,
     covers: HashMap<String, image::Handle>,
+    pub cover_loader_addr: Option<SocketAddr>,
 
     sync_x_fader_is_left: bool,
 
@@ -88,8 +97,6 @@ pub struct TraktorDataProvider {
     cached_next_song_info: Option<SongInfo>,
     cached_sync_action: TraktorSyncAction,
     should_scroll: bool,
-
-    pub client: Option<SocketAddr>,
 
     pub debug_logging: bool,
     log: Vec<String>,
@@ -119,7 +126,7 @@ impl Default for TraktorDataProvider {
             cached_sync_action: TraktorSyncAction::Relative(0),
             should_scroll: false,
 
-            client: None,
+            cover_loader_addr: None,
 
             debug_logging: false,
             log: Vec::new(),
@@ -130,7 +137,8 @@ impl Default for TraktorDataProvider {
 impl TraktorDataProvider {
     pub fn set_enabled(&mut self, enabled: bool) {
         self.enabled = enabled;
-        self.client = None;
+        self.cover_loader_addr = None;
+        self.state = None;
     }
     pub fn is_ready(&self) -> bool {
         self.enabled && self.channel.as_ref().is_some_and(|c| !c.is_closed())
@@ -185,8 +193,18 @@ impl TraktorDataProvider {
         self.cached_next_song_info.as_ref()
     }
 
-    pub fn connected_client(&self) -> Option<SocketAddr> {
-        self.client
+    pub fn get_connection_state(&self) -> ConnectionState {
+        if !self.enabled {
+            ConnectionState::Disconnected
+        } else if self.cover_loader_addr.is_some() && self.state.is_some() {
+            ConnectionState::Connected
+        } else if self.state.is_some() {
+            ConnectionState::Traktor
+        } else if self.cover_loader_addr.is_some() {
+            ConnectionState::CoverLoader
+        } else {
+            ConnectionState::Disconnected
+        }
     }
 
     fn get_deck_score(&self, deck: &DeckState, channel: &ChannelState, mixer: &MixerState) -> f64 {
@@ -459,7 +477,7 @@ impl TraktorDataProvider {
                 }
             }
             ServerMessage::ClientChanged(addr) => {
-                self.client = addr;
+                self.cover_loader_addr = addr;
             }
         }
     }
@@ -502,10 +520,9 @@ mod tests {
     use super::*;
     use iced::futures::channel::mpsc;
 
-    /// `connected_client()` reflects the latest `ClientsChanged` only while the
-    /// server is ready, and `Ready` clears the list (server restarted).
+    /// After receiving a ClientChanged message, the provider should be in the CoverLoader state.
     #[test]
-    fn connected_clients_gating_and_reset() {
+    fn connecting_cover_loader_and_trakor_sets_connection_state() {
         // Keep the receivers alive so the channel counts as "open" (ready).
         let (tx, _rx) = mpsc::unbounded();
         let mut provider = TraktorDataProvider {
@@ -514,12 +531,18 @@ mod tests {
             ..Default::default()
         };
 
-        assert!(provider.connected_client().is_none());
+        assert!(matches!(
+            provider.get_connection_state(),
+            ConnectionState::Disconnected
+        ));
 
         provider.process_message(
             ServerMessage::ClientChanged(Some("127.0.0.1:8080".parse().unwrap())),
             &[],
         );
-        assert!(provider.connected_client().is_some());
+        assert!(matches!(
+            provider.get_connection_state(),
+            ConnectionState::CoverLoader
+        ));
     }
 }

--- a/src/traktor_api/data_provider.rs
+++ b/src/traktor_api/data_provider.rs
@@ -521,13 +521,5 @@ mod tests {
             &[],
         );
         assert!(provider.connected_client().is_some());
-
-        provider.enabled = false;
-        assert!(provider.connected_client().is_none());
-
-        // A fresh server start (Ready) resets the tracked clients.
-        let (tx, _rx2) = mpsc::unbounded();
-        provider.process_message(ServerMessage::Ready(tx), &[]);
-        assert!(provider.connected_client().is_none());
     }
 }

--- a/src/traktor_api/data_provider.rs
+++ b/src/traktor_api/data_provider.rs
@@ -67,9 +67,9 @@ pub enum TraktorMessage {
 }
 
 pub struct TraktorDataProvider {
-    pub is_enabled: bool,
     pub address: String,
     pub submitted_address: String,
+    enabled: bool,
 
     pub next_mode: TraktorNextMode,
     pub next_mode_fallback: TraktorNextMode,
@@ -89,6 +89,8 @@ pub struct TraktorDataProvider {
     cached_sync_action: TraktorSyncAction,
     should_scroll: bool,
 
+    pub client: Option<SocketAddr>,
+
     pub debug_logging: bool,
     log: Vec<String>,
 }
@@ -96,7 +98,7 @@ pub struct TraktorDataProvider {
 impl Default for TraktorDataProvider {
     fn default() -> Self {
         Self {
-            is_enabled: false,
+            enabled: false,
             address: String::new(),
             submitted_address: String::new(),
             channel: None,
@@ -117,6 +119,8 @@ impl Default for TraktorDataProvider {
             cached_sync_action: TraktorSyncAction::Relative(0),
             should_scroll: false,
 
+            client: None,
+
             debug_logging: false,
             log: Vec::new(),
         }
@@ -124,8 +128,12 @@ impl Default for TraktorDataProvider {
 }
 
 impl TraktorDataProvider {
+    pub fn set_enabled(&mut self, enabled: bool) {
+        self.enabled = enabled;
+        self.client = None;
+    }
     pub fn is_ready(&self) -> bool {
-        self.is_enabled && self.channel.as_ref().is_some_and(|c| !c.is_closed())
+        self.enabled && self.channel.as_ref().is_some_and(|c| !c.is_closed())
     }
 
     #[allow(dead_code)]
@@ -150,7 +158,7 @@ impl TraktorDataProvider {
     }
 
     pub fn get_socket_addr(&self) -> Option<SocketAddr> {
-        if !self.is_enabled {
+        if !self.enabled {
             return None;
         }
 
@@ -175,6 +183,10 @@ impl TraktorDataProvider {
         }
 
         self.cached_next_song_info.as_ref()
+    }
+
+    pub fn connected_client(&self) -> Option<SocketAddr> {
+        self.client
     }
 
     fn get_deck_score(&self, deck: &DeckState, channel: &ChannelState, mixer: &MixerState) -> f64 {
@@ -446,6 +458,9 @@ impl TraktorDataProvider {
                     self.log.push(msg);
                 }
             }
+            ServerMessage::ClientChanged(addr) => {
+                self.client = addr;
+            }
         }
     }
 
@@ -475,5 +490,44 @@ impl TraktorDataProvider {
         {
             self.channel = None;
         }
+    }
+
+    pub fn enabled(&self) -> bool {
+        self.enabled
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use iced::futures::channel::mpsc;
+
+    /// `connected_client()` reflects the latest `ClientsChanged` only while the
+    /// server is ready, and `Ready` clears the list (server restarted).
+    #[test]
+    fn connected_clients_gating_and_reset() {
+        // Keep the receivers alive so the channel counts as "open" (ready).
+        let (tx, _rx) = mpsc::unbounded();
+        let mut provider = TraktorDataProvider {
+            enabled: true,
+            channel: Some(tx),
+            ..Default::default()
+        };
+
+        assert!(provider.connected_client().is_none());
+
+        provider.process_message(
+            ServerMessage::ClientChanged(Some("127.0.0.1:8080".parse().unwrap())),
+            &[],
+        );
+        assert!(provider.connected_client().is_some());
+
+        provider.enabled = false;
+        assert!(provider.connected_client().is_none());
+
+        // A fresh server start (Ready) resets the tracked clients.
+        let (tx, _rx2) = mpsc::unbounded();
+        provider.process_message(ServerMessage::Ready(tx), &[]);
+        assert!(provider.connected_client().is_none());
     }
 }

--- a/src/traktor_api/model.rs
+++ b/src/traktor_api/model.rs
@@ -116,7 +116,7 @@ impl<'de> Deserialize<'de> for State {
     }
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, Copy)]
 #[serde(rename_all = "camelCase")]
 pub struct MixerState {
     pub x_fader: f64,
@@ -126,7 +126,7 @@ pub struct MixerState {
     pub mic_volume: f64,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, Copy)]
 #[serde(rename_all = "camelCase")]
 pub struct ChannelState {
     pub cue: bool,
@@ -161,7 +161,7 @@ pub struct DeckContentState {
     pub bpm: f64,
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, Copy)]
 pub struct DeckPlayState {
     pub timestamp: u64,
     pub position: f64,

--- a/src/traktor_api/model.rs
+++ b/src/traktor_api/model.rs
@@ -1,6 +1,7 @@
 use bytes::Bytes;
 use iced::futures::channel::mpsc;
 use serde::{Deserialize, Deserializer, Serialize};
+use std::net::SocketAddr;
 
 #[derive(Debug, Clone)]
 pub enum AppMessage {
@@ -19,6 +20,7 @@ pub enum ServerMessage {
         path: String,
         data: Bytes,
     },
+    ClientChanged(Option<SocketAddr>),
     Log(String),
 }
 

--- a/src/traktor_api/server.rs
+++ b/src/traktor_api/server.rs
@@ -195,7 +195,11 @@ impl TraktorServer {
         StatusCode::ACCEPTED
     }
 
-    async fn handle_socket_connect(&mut self, mut tx: UnboundedSender<warp::ws::Message>) -> usize {
+    async fn handle_socket_connect(
+        &mut self,
+        mut tx: UnboundedSender<warp::ws::Message>,
+        addr: Option<SocketAddr>,
+    ) -> usize {
         while self.cover_sockets.contains_key(&self.cover_socket_id) {
             self.cover_socket_id += 1;
         }
@@ -205,11 +209,13 @@ impl TraktorServer {
         }
 
         self.cover_sockets.insert(self.cover_socket_id, tx);
+        self.send_message(ServerMessage::ClientChanged(addr)).await;
         self.cover_socket_id
     }
 
-    fn handle_socket_disconnect(&mut self, id: usize) {
+    async fn handle_socket_disconnect(&mut self, id: usize, addr: Option<SocketAddr>) {
         self.cover_sockets.remove(&id);
+        self.send_message(ServerMessage::ClientChanged(addr)).await;
     }
 
     async fn handle_log(&mut self, msg: String) -> impl warp::Reply + use<> {
@@ -405,39 +411,46 @@ impl TraktorServer {
     ) -> impl Filter<Extract = (impl warp::Reply,), Error = warp::Rejection> + Clone {
         warp::ws()
             .and(Self::with_state(state))
-            .map(|ws: warp::ws::Ws, state: Arc<Mutex<Self>>| {
-                ws.on_upgrade(move |socket| async move {
-                    let (mut ws_tx, mut ws_rx) = socket.split();
-                    let (tx, mut rx) = iced::futures::channel::mpsc::unbounded();
+            .and(warp::addr::remote())
+            .map(
+                |ws: warp::ws::Ws, state: Arc<Mutex<Self>>, addr: Option<SocketAddr>| {
+                    ws.on_upgrade(move |socket| async move {
+                        let (mut ws_tx, mut ws_rx) = socket.split();
+                        let (tx, mut rx) = iced::futures::channel::mpsc::unbounded();
 
-                    tokio::task::spawn(async move {
-                        while let Some(message) = rx.next().await {
-                            ws_tx
-                                .send(message)
-                                .unwrap_or_else(|e| {
-                                    println!("websocket send error: {}", e);
-                                })
-                                .await;
-                        }
-                    });
-
-                    let socket_id = state.lock().await.handle_socket_connect(tx).await;
-                    println!("websocket connected");
-
-                    while let Some(result) = ws_rx.next().await {
-                        match result {
-                            Ok(_) => {}
-                            Err(e) => {
-                                println!("websocket error: {}", e);
-                                break;
+                        tokio::task::spawn(async move {
+                            while let Some(message) = rx.next().await {
+                                ws_tx
+                                    .send(message)
+                                    .unwrap_or_else(|e| {
+                                        println!("websocket send error: {}", e);
+                                    })
+                                    .await;
                             }
-                        };
-                    }
+                        });
 
-                    state.lock().await.handle_socket_disconnect(socket_id);
-                    println!("websocket disconnected");
-                })
-            })
+                        let socket_id = state.lock().await.handle_socket_connect(tx, addr).await;
+                        println!("websocket connected");
+
+                        while let Some(result) = ws_rx.next().await {
+                            match result {
+                                Ok(_) => {}
+                                Err(e) => {
+                                    println!("websocket error: {}", e);
+                                    break;
+                                }
+                            };
+                        }
+
+                        state
+                            .lock()
+                            .await
+                            .handle_socket_disconnect(socket_id, None)
+                            .await;
+                        println!("websocket disconnected");
+                    })
+                },
+            )
     }
 
     fn route_log(
@@ -546,10 +559,7 @@ mod tests {
     // -- Shared test helpers --
 
     /// Creates a fresh server state and returns the message receiver alongside it.
-    fn new_state() -> (
-        Arc<Mutex<TraktorServer>>,
-        iced_mpsc::UnboundedReceiver<ServerMessage>,
-    ) {
+    fn new_state() -> (Arc<Mutex<TraktorServer>>, UnboundedReceiver<ServerMessage>) {
         let (tx, rx) = iced_mpsc::unbounded();
         (Arc::new(Mutex::new(TraktorServer::new(tx))), rx)
     }
@@ -613,7 +623,7 @@ mod tests {
     }
 
     /// Awaits the next message with a 500 ms timeout, panicking on timeout.
-    async fn recv_msg(rx: &mut iced_mpsc::UnboundedReceiver<ServerMessage>) -> ServerMessage {
+    async fn recv_msg(rx: &mut UnboundedReceiver<ServerMessage>) -> ServerMessage {
         timeout(Duration::from_millis(500), rx.next())
             .await
             .expect("timeout waiting for ServerMessage")
@@ -621,7 +631,7 @@ mod tests {
     }
 
     /// Asserts that no message arrives within 500 ms.
-    async fn assert_no_msg(rx: &mut iced_mpsc::UnboundedReceiver<ServerMessage>) {
+    async fn assert_no_msg(rx: &mut UnboundedReceiver<ServerMessage>) {
         let result = timeout(Duration::from_millis(500), rx.next()).await;
         assert!(
             result.is_err(),
@@ -758,7 +768,7 @@ mod tests {
 
         let filter = TraktorServer::routes(state);
 
-        // Queue two mixer updates before initialising
+        // Queue two mixer updates before initializing
         for _ in 0..2 {
             warp::test::request()
                 .method("POST")

--- a/src/traktor_api/server.rs
+++ b/src/traktor_api/server.rs
@@ -213,9 +213,9 @@ impl TraktorServer {
         self.cover_socket_id
     }
 
-    async fn handle_socket_disconnect(&mut self, id: usize, addr: Option<SocketAddr>) {
+    async fn handle_socket_disconnect(&mut self, id: usize) {
         self.cover_sockets.remove(&id);
-        self.send_message(ServerMessage::ClientChanged(addr)).await;
+        self.send_message(ServerMessage::ClientChanged(None)).await;
     }
 
     async fn handle_log(&mut self, msg: String) -> impl warp::Reply + use<> {
@@ -442,11 +442,7 @@ impl TraktorServer {
                             };
                         }
 
-                        state
-                            .lock()
-                            .await
-                            .handle_socket_disconnect(socket_id, None)
-                            .await;
+                        state.lock().await.handle_socket_disconnect(socket_id).await;
                         println!("websocket disconnected");
                     })
                 },
@@ -1291,6 +1287,38 @@ mod tests {
                 matches!(rebind, Ok(Ok(_))),
                 "port should be available after server drop"
             );
+        }
+
+        // -- client tracking (cover WebSocket connections) --
+
+        /// Connecting a cover socket emits ClientsChanged carrying the remote
+        /// address; disconnecting emits ClientsChanged with the client removed.
+        #[tokio::test]
+        async fn socket_connect_and_disconnect_emit_client_list() {
+            let (state, mut rx) = new_state();
+            let addr: SocketAddr = "1.2.3.4:5678".parse().unwrap();
+
+            let (tx, _ws_rx) = iced_mpsc::unbounded();
+            let id = state
+                .lock()
+                .await
+                .handle_socket_connect(tx, Some(addr))
+                .await;
+
+            let msg = recv_msg(&mut rx).await;
+            assert!(matches!(
+                &msg,
+                ServerMessage::ClientChanged(addr)
+                    if addr.is_some()
+            ));
+
+            state.lock().await.handle_socket_disconnect(id).await;
+
+            let msg = recv_msg(&mut rx).await;
+            assert!(matches!(
+                &msg,
+                ServerMessage::ClientChanged(client) if client.is_none()
+            ));
         }
     }
 }

--- a/src/traktor_api/server.rs
+++ b/src/traktor_api/server.rs
@@ -1294,7 +1294,7 @@ mod tests {
         /// Connecting a cover socket emits ClientsChanged carrying the remote
         /// address; disconnecting emits ClientsChanged with the client removed.
         #[tokio::test]
-        async fn socket_connect_and_disconnect_emit_client_list() {
+        async fn cover_loader_connect_disconnect_changes_state() {
             let (state, mut rx) = new_state();
             let addr: SocketAddr = "1.2.3.4:5678".parse().unwrap();
 

--- a/src/traktor_api/server.rs
+++ b/src/traktor_api/server.rs
@@ -487,8 +487,12 @@ async fn server_main(
         return;
     };
 
-    let server = warp::serve(routes).incoming(listener).graceful(async {
+    let state_clone = state.clone();
+    let server = warp::serve(routes).incoming(listener).graceful(async move {
         cancelled.await.ok();
+        for socket in state_clone.lock().await.cover_sockets.values_mut() {
+            let _ = socket.send(warp::ws::Message::close()).await;
+        }
     });
 
     tokio::task::spawn(server.run());

--- a/src/ui/config_window/sidebar.rs
+++ b/src/ui/config_window/sidebar.rs
@@ -9,8 +9,10 @@ use crate::ui::widget::{power_button, restart_button, suggestion_text_input};
 use crate::ui::with_tooltip;
 use crate::{DanceInterpreter, Message};
 use iced::alignment::Vertical;
-use iced::widget::{Container, canvas, column as col, container, pick_list, row, text};
-use iced::{Alignment, Animation, Length, animation};
+use iced::widget::{
+    Column, Container, Space, canvas, column as col, container, pick_list, row, text,
+};
+use iced::{Alignment, Animation, Length, animation, border};
 use network_interface::Addr::V4;
 use network_interface::{NetworkInterface, NetworkInterfaceConfig};
 use std::time::Duration;
@@ -66,7 +68,7 @@ impl Sidebar {
                     col![
                         with_tooltip(
                             CanvasToggle::new(
-                                dance_interpreter.data_provider.traktor_provider.is_enabled,
+                                dance_interpreter.data_provider.traktor_provider.enabled(),
                                 &self.power_button_cache
                             )
                             .on_toggle(|b| Message::Traktor(TraktorMessage::EnableServer(b)))
@@ -79,7 +81,7 @@ impl Sidebar {
                     col![
                         with_tooltip(
                             CanvasToggle::new(
-                                dance_interpreter.data_provider.traktor_provider.is_enabled,
+                                dance_interpreter.data_provider.traktor_provider.enabled(),
                                 &self.restart_button_cache
                             )
                             .on_toggle(|_| Message::Traktor(TraktorMessage::Reconnect))
@@ -91,6 +93,7 @@ impl Sidebar {
                     .align_x(Alignment::Center)
                 ]
                 .spacing(10),
+                Self::build_client_status(dance_interpreter),
                 col![
                     text("Server Address: "),
                     self.build_network_interface_combo_box(dance_interpreter)
@@ -155,6 +158,21 @@ impl Sidebar {
         .align_y(Vertical::Top)
     }
 
+    pub fn update_network_interface_selection(&mut self, song_data_provider: &SongDataProvider) {
+        let mut detected_interfaces: Vec<String> =
+            get_formatted_network_interfaces(song_data_provider)
+                .into_iter()
+                .map(|(_, _, formatted)| formatted)
+                .collect();
+        detected_interfaces.push(TRAKTOR_SERVER_DEFAULT_ADDR.to_owned());
+        detected_interfaces.sort();
+
+        self.server_address_presets = suggestion_text_input::State::with_selection(
+            detected_interfaces,
+            Some(&song_data_provider.traktor_provider.address.clone()),
+        );
+    }
+
     fn build_network_interface_combo_box(
         &'_ self,
         dance_interpreter: &DanceInterpreter,
@@ -175,19 +193,53 @@ impl Sidebar {
         .on_close(Message::Traktor(TraktorMessage::SubmitAddress))
     }
 
-    pub fn update_network_interface_selection(&mut self, song_data_provider: &SongDataProvider) {
-        let mut detected_interfaces: Vec<String> =
-            get_formatted_network_interfaces(song_data_provider)
-                .into_iter()
-                .map(|(_, _, formatted)| formatted)
-                .collect();
-        detected_interfaces.push(TRAKTOR_SERVER_DEFAULT_ADDR.to_owned());
-        detected_interfaces.sort();
+    /// A small LED + label showing whether a Traktor client is
+    /// connected, listing client's IP available.
+    fn build_client_status<'a>(dance_interpreter: &DanceInterpreter) -> Column<'a, Message> {
+        let client = dance_interpreter
+            .data_provider
+            .traktor_provider
+            .connected_client();
 
-        self.server_address_presets = suggestion_text_input::State::with_selection(
-            detected_interfaces,
-            Some(&song_data_provider.traktor_provider.address.clone()),
-        );
+        let led = container(Space::new())
+            .width(Length::Fixed(12.0))
+            .height(Length::Fixed(12.0))
+            .style(move |t: &iced::Theme| {
+                let palette = t.extended_palette();
+                let color = if client.is_some() {
+                    palette.success.base.color
+                } else {
+                    palette.background.strong.color
+                };
+                container::Style {
+                    background: Some(color.into()),
+                    border: border::rounded(6.0),
+                    ..container::Style::default()
+                }
+            });
+
+        let summary = if client.is_some() {
+            "Client connected".to_owned()
+        } else {
+            "No client connected".to_owned()
+        };
+
+        let mut column = col![
+            row![led, text(summary)]
+                .spacing(8)
+                .align_y(Alignment::Center)
+        ]
+        .spacing(4)
+        .width(Length::Fill)
+        .align_x(Alignment::Center);
+
+        let label = client.map(|addr| addr.ip().to_string());
+
+        if let Some(label) = label {
+            column = column.push(text(label).size(12));
+        }
+
+        column
     }
 }
 

--- a/src/ui/config_window/sidebar.rs
+++ b/src/ui/config_window/sidebar.rs
@@ -1,6 +1,6 @@
 use crate::dataloading::dataprovider::song_data_provider::SongDataProvider;
 use crate::traktor_api::{
-    TRAKTOR_SERVER_DEFAULT_ADDR, TraktorMessage, TraktorNextMode, TraktorSyncMode,
+    ConnectionState, TRAKTOR_SERVER_DEFAULT_ADDR, TraktorMessage, TraktorNextMode, TraktorSyncMode,
 };
 use crate::ui::config_window::labeled_message_toggler;
 use crate::ui::widget::canvas_toggle::CanvasToggle;
@@ -196,20 +196,22 @@ impl Sidebar {
     /// A small LED + label showing whether a Traktor client is
     /// connected, listing client's IP available.
     fn build_client_status<'a>(dance_interpreter: &DanceInterpreter) -> Column<'a, Message> {
-        let client = dance_interpreter
+        let client_connection_state = dance_interpreter
             .data_provider
             .traktor_provider
-            .connected_client();
+            .get_connection_state();
 
         let led = container(Space::new())
             .width(Length::Fixed(12.0))
             .height(Length::Fixed(12.0))
             .style(move |t: &iced::Theme| {
                 let palette = t.extended_palette();
-                let color = if client.is_some() {
-                    palette.success.base.color
-                } else {
-                    palette.background.strong.color
+                let color = match client_connection_state {
+                    ConnectionState::Connected => palette.success.base.color,
+                    ConnectionState::CoverLoader | ConnectionState::Traktor => {
+                        palette.warning.base.color
+                    }
+                    ConnectionState::Disconnected => palette.background.strong.color,
                 };
                 container::Style {
                     background: Some(color.into()),
@@ -218,10 +220,11 @@ impl Sidebar {
                 }
             });
 
-        let summary = if client.is_some() {
-            "Client connected".to_owned()
-        } else {
-            "No client connected".to_owned()
+        let summary = match client_connection_state {
+            ConnectionState::Connected => "Traktor & Cover Loader connected",
+            ConnectionState::Traktor => "Traktor connected",
+            ConnectionState::CoverLoader => "Cover Loader connected",
+            ConnectionState::Disconnected => "No client connected",
         };
 
         let mut column = col![
@@ -233,7 +236,11 @@ impl Sidebar {
         .width(Length::Fill)
         .align_x(Alignment::Center);
 
-        let label = client.map(|addr| addr.ip().to_string());
+        let label = dance_interpreter
+            .data_provider
+            .traktor_provider
+            .cover_loader_addr
+            .map(|addr| addr.ip().to_string());
 
         if let Some(label) = label {
             column = column.push(text(label).size(12));


### PR DESCRIPTION
Adds a connection indicator to the server settings sidebar showing whether a Traktor client is connected, and it's IP address.

Fixes server not properly closing client connections when stopped

Closes #184 .