### PR TITLE
Add first run experience

### DIFF
--- a/src/ui/config_window/mod.rs
+++ b/src/ui/config_window/mod.rs
@@ -122,6 +122,10 @@ impl ConfigWindow {
     }
 
     fn build_playlist_view(&'_ self, dance_interpreter: &DanceInterpreter) -> Column<'_, Message> {
+        if dance_interpreter.data_provider.playlist_songs.is_empty() {
+            return self.build_empty_playlist_view();
+        }
+
         let trow: Row<_> = row![
             text!("#").width(Length::Fixed(24.0)),
             text!("Title").width(Length::Fill),
@@ -258,9 +262,43 @@ impl ConfigWindow {
         col!(trow, playlist_scrollable).spacing(5)
     }
 
+    fn build_empty_playlist_view(&'_ self) -> Column<'_, Message> {
+        let empty_state_column = col![
+            text("No playlist loaded.").size(24),
+            text("Click the folder icon below to load a playlist (.m3u) file.").size(16),
+            button(material_icon_sized("folder_open", 64))
+                .style(empty_folder_button_style)
+                .on_press(Message::OpenPlaylist)
+                .padding(20)
+        ]
+        .spacing(20)
+        .align_x(Alignment::Center);
+
+        col![
+            Space::new().height(Length::Fill),
+            empty_state_column,
+            Space::new().height(Length::Fill)
+        ]
+        .width(Length::Fill)
+        .height(Length::Fill)
+        .align_x(Alignment::Center)
+    }
+
     fn build_statics_view(&'_ self, _dance_interpreter: &DanceInterpreter) -> Column<'_, Message> {
         col![].width(Length::Fill).height(Length::Fill)
     }
+}
+
+fn empty_folder_button_style(
+    theme: &Theme,
+    status: iced::widget::button::Status,
+) -> iced::widget::button::Style {
+    let palette = theme.extended_palette();
+    let mut style = button::text(theme, status);
+    style.text_color = palette.secondary.strong.color;
+    style.background = Some(palette.background.weakest.color.into());
+    style.border.radius = 12.0.into();
+    style
 }
 
 fn label_message_button_fill<'a>(

--- a/src/ui/config_window/mod.rs
+++ b/src/ui/config_window/mod.rs
@@ -5,7 +5,7 @@ pub mod top_bar;
 use crate::dataloading::dataprovider::song_data_provider::{
     SongChange, SongDataEdit, SongDataSource,
 };
-use crate::ui::config_window::sidebar::Sidebar;
+use crate::ui::config_window::sidebar::{Sidebar, SidebarMessage};
 use crate::ui::widget::dynamic_text_input::DynamicTextInput;
 use crate::ui::{material_icon, material_icon_sized, with_tooltip};
 use crate::{DanceInterpreter, Message, Window};
@@ -263,15 +263,41 @@ impl ConfigWindow {
     }
 
     fn build_empty_playlist_view(&'_ self) -> Column<'_, Message> {
-        let empty_state_column = col![
-            text("No playlist loaded.").size(24),
-            text("Click the folder icon below to load a playlist (.m3u) file.").size(16),
+        let playlist_col = col![
+            text("Load Playlist").size(20),
+            text("Click the folder icon below to load a playlist (.m3u) file.")
+                .size(16)
+                .width(Length::Fixed(300.0))
+                .align_x(Alignment::Center),
             button(material_icon_sized("folder_open", 64))
                 .style(empty_folder_button_style)
                 .on_press(Message::OpenPlaylist)
                 .padding(20)
         ]
         .spacing(20)
+        .align_x(Alignment::Center);
+
+        let traktor_col = col![
+            text("Use Traktor").size(20),
+            text("Open the sidebar to start the Traktor server and sync automatically.")
+                .size(16)
+                .width(Length::Fixed(300.0))
+                .align_x(Alignment::Center),
+            button(material_icon_sized("agriculture", 64))
+                .style(empty_folder_button_style)
+                .on_press(Message::Sidebar(SidebarMessage::Toggle))
+                .padding(20)
+        ]
+        .spacing(20)
+        .align_x(Alignment::Center);
+
+        let empty_state_column = col![
+            text("No playlist loaded.").size(24),
+            row![playlist_col, traktor_col]
+                .spacing(40)
+                .align_y(Alignment::Center)
+        ]
+        .spacing(40)
         .align_x(Alignment::Center);
 
         col![


### PR DESCRIPTION
Adds an onboarding experience:
- tells the user that no playlist is loaded → no data
- suggests to either load a playlist or use the Traktor server to get displayable data

closes #185 