### PR TITLE
[FEAT] Delete confirmation modal and undo (#182)

### DIFF
--- a/src/dataloading/dataprovider/mod.rs
+++ b/src/dataloading/dataprovider/mod.rs
@@ -5,6 +5,18 @@ use crate::traktor_api;
 use crate::traktor_api::TraktorDataProvider;
 use std::cmp::PartialEq;
 
+pub enum DeletedItem {
+    Playlist {
+        index: usize,
+        song: SongInfo,
+        played: bool,
+    },
+    Static {
+        index: usize,
+        static_info: StaticInfo,
+    },
+}
+
 #[derive(Default, Debug, PartialEq, Clone)]
 pub enum ItemSource {
     #[default]
@@ -42,6 +54,8 @@ pub struct DataProvider {
     pub playlist_played: Vec<bool>,
 
     pub statics: Vec<StaticInfo>,
+
+    pub deleted_items: Vec<DeletedItem>,
 
     pub traktor_provider: TraktorDataProvider,
 
@@ -202,10 +216,39 @@ impl DataProvider {
         }
 
         if let ItemSource::Playlist(i) = song {
-            self.playlist_songs.remove(i);
-            self.playlist_played.remove(i);
+            let song_info = self.playlist_songs.remove(i);
+            let played = self.playlist_played.remove(i);
+            self.deleted_items.push(DeletedItem::Playlist {
+                index: i,
+                song: song_info,
+                played,
+            });
         } else if let ItemSource::Static(i) = song {
-            self.statics.remove(i);
+            let static_info = self.statics.remove(i);
+            self.deleted_items.push(DeletedItem::Static {
+                index: i,
+                static_info,
+            });
+        }
+    }
+
+    pub fn undo_delete(&mut self) {
+        if let Some(item) = self.deleted_items.pop() {
+            match item {
+                DeletedItem::Playlist {
+                    index,
+                    song,
+                    played,
+                } => {
+                    let insert_idx = index.min(self.playlist_songs.len());
+                    self.playlist_songs.insert(insert_idx, song);
+                    self.playlist_played.insert(insert_idx, played);
+                }
+                DeletedItem::Static { index, static_info } => {
+                    let insert_idx = index.min(self.statics.len());
+                    self.statics.insert(insert_idx, static_info);
+                }
+            }
         }
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,7 @@ struct DanceInterpreter {
     song_window: SongWindow,
 
     data_provider: DataProvider,
+    modifiers: Modifiers,
 }
 
 #[derive(Debug, Clone)]
@@ -107,6 +108,12 @@ pub enum Message {
 
     Animate,
     Traktor(TraktorMessage),
+
+    RequestDelete(ItemSource),
+    ConfirmDelete,
+    CancelDelete,
+    UndoDelete,
+    ModifiersChanged(Modifiers),
 }
 
 impl DanceInterpreter {
@@ -135,6 +142,7 @@ impl DanceInterpreter {
             song_window,
 
             data_provider: DataProvider::default(),
+            modifiers: Modifiers::default(),
         };
 
         tasks.push(cw_opened);
@@ -197,6 +205,10 @@ impl DanceInterpreter {
 
         match message {
             Message::WindowOpened(_) => ().into(),
+            Message::ModifiersChanged(modifiers) => {
+                self.modifiers = modifiers;
+                ().into()
+            }
             Message::WindowResized((window_id, size)) => {
                 if self.config_window.id == window_id {
                     self.config_window.on_resize(size);
@@ -413,6 +425,33 @@ impl DanceInterpreter {
 
             Message::DeleteItem(song) => {
                 self.data_provider.delete_item(song);
+                ().into()
+            }
+
+            Message::UndoDelete => {
+                self.data_provider.undo_delete();
+                self.save_statics();
+                ().into()
+            }
+
+            Message::RequestDelete(source) => {
+                if self.modifiers.shift() {
+                    return Task::done(Message::DeleteItem(source));
+                }
+
+                self.config_window.pending_delete = Some(source);
+                ().into()
+            }
+
+            Message::ConfirmDelete => {
+                if let Some(source) = self.config_window.pending_delete.take() {
+                    return Task::done(Message::DeleteItem(source));
+                }
+                ().into()
+            }
+
+            Message::CancelDelete => {
+                self.config_window.pending_delete = None;
                 ().into()
             }
 
@@ -671,6 +710,9 @@ impl DanceInterpreter {
                 _ => Message::Noop,
             }),
             keyboard::listen().filter_map(|event| {
+                if let keyboard::Event::ModifiersChanged(modifiers) = event {
+                    return Some(Message::ModifiersChanged(modifiers));
+                }
                 let keyboard::Event::KeyPressed { key, .. } = event else {
                     return None;
                 };
@@ -698,6 +740,7 @@ impl DanceInterpreter {
                 };
                 match (key.as_ref(), modifiers) {
                     (Key::Character("n"), Modifiers::CTRL) => Some(Message::AddBlankEntry),
+                    (Key::Character("z"), Modifiers::CTRL) => Some(Message::UndoDelete),
                     (Key::Character("+"), Modifiers::CTRL) => {
                         Some(Message::ChangeSongWindowScale(0.1))
                     }

--- a/src/ui/config_window/mod.rs
+++ b/src/ui/config_window/mod.rs
@@ -18,8 +18,8 @@ use fuzzy_matcher::FuzzyMatcher;
 use fuzzy_matcher::skim::SkimMatcherV2 as Matcher;
 use iced::alignment::Vertical;
 use iced::widget::{
-    Column, Container, Row, Scrollable, Space, TextInput, button, column as col, container, row,
-    scrollable, text,
+    Column, Container, Row, Scrollable, Space, TextInput, button, column as col, container,
+    mouse_area, opaque, row, scrollable, stack, text,
 };
 use iced::{Alignment, Color, Element, Length, Size, Theme, window};
 use std::sync::LazyLock;
@@ -37,6 +37,8 @@ pub struct ConfigWindow {
 
     pub search_visible: bool,
     pub search_query: String,
+
+    pub pending_delete: Option<ItemSource>,
 }
 
 pub static PLAYLIST_SCROLLABLE_ID: LazyLock<iced::widget::Id> =
@@ -57,6 +59,7 @@ impl Window for ConfigWindow {
 
             search_visible: false,
             search_query: String::new(),
+            pending_delete: None,
         }
     }
 
@@ -101,10 +104,83 @@ impl ConfigWindow {
                 Instant::now(),
             ));
         let bottom_bar = bottombar::build(dance_interpreter);
+        let main_view = col![row![main_column, side_bar], bottom_bar].spacing(5);
 
-        col![row![main_column, side_bar], bottom_bar]
-            .spacing(5)
-            .into()
+        if let Some(source) = &self.pending_delete {
+            let target_name = match source {
+                ItemSource::Playlist(i) => dance_interpreter
+                    .data_provider
+                    .playlist_songs
+                    .get(*i)
+                    .map(|s| s.title.clone())
+                    .unwrap_or_default(),
+                ItemSource::Static(i) => dance_interpreter
+                    .data_provider
+                    .statics
+                    .get(*i)
+                    .map(|s| s.name.clone())
+                    .unwrap_or_default(),
+                _ => String::new(),
+            };
+
+            let dialog = self.build_delete_dialog(target_name);
+            stack![main_view, dialog].into()
+        } else {
+            main_view.into()
+        }
+    }
+
+    fn build_delete_dialog(&self, target: String) -> Element<'_, Message> {
+        let card = container(
+            col![
+                text("Delete item?").size(20),
+                text(target),
+                row![
+                    button(text("Cancel").align_x(Alignment::Center))
+                        .padding([4, 8])
+                        .style(button::secondary)
+                        .on_press(Message::CancelDelete)
+                        .width(Length::Fill),
+                    button(text("Delete").align_x(Alignment::Center))
+                        .padding([4, 8])
+                        .style(button::danger)
+                        .on_press(Message::ConfirmDelete)
+                        .width(Length::Fill),
+                ]
+                .spacing(10),
+            ]
+            .spacing(15)
+            .width(Length::Fixed(360.0)),
+        )
+        .padding(20)
+        .style(|t: &Theme| {
+            let palette = t.extended_palette();
+            container::Style::default()
+                .background(palette.background.base.color)
+                .border(iced::Border {
+                    color: palette.background.strong.color,
+                    width: 1.0,
+                    radius: 8.0.into(),
+                })
+        });
+
+        let backdrop = mouse_area(
+            container(Space::new().width(Length::Fill).height(Length::Fill))
+                .width(Length::Fill)
+                .height(Length::Fill)
+                .style(|_t: &Theme| {
+                    container::Style::default().background(Color::from_rgba(0.0, 0.0, 0.0, 0.5))
+                }),
+        )
+        .on_press(Message::CancelDelete);
+
+        let centered_card = container(opaque(card))
+            .width(Length::Fill)
+            .height(Length::Fill)
+            .align_x(Alignment::Center)
+            .align_y(Alignment::Center);
+
+        opaque(stack![backdrop, centered_card])
     }
 
     fn build_search_bar<'a>(&self) -> Row<'a, Message> {
@@ -292,7 +368,7 @@ impl ConfigWindow {
                     material_symbol_message_button(
                         "delete",
                         false,
-                        Message::DeleteItem(ItemSource::Static(idx))
+                        Message::RequestDelete(ItemSource::Static(idx))
                     ),
                     "Delete static"
                 ),
@@ -368,7 +444,7 @@ impl ConfigWindow {
                     material_symbol_message_button(
                         "delete",
                         false,
-                        Message::DeleteItem(ItemSource::Playlist(idx))
+                        Message::RequestDelete(ItemSource::Playlist(idx))
                     ),
                     "Delete song"
                 ),

--- a/src/ui/config_window/top_bar.rs
+++ b/src/ui/config_window/top_bar.rs
@@ -65,6 +65,7 @@ pub fn build<'a>(
                         .width(Length::Fill)),
                         (label_message_button_fill("Reload Statics", Message::ReloadStatics)),
                         (label_message_button_fill(format!("Add blank {}", if config_window.is_statics_view {"static"} else {"song"}), Message::AddBlankEntry)),
+                        (label_message_button_fill("Undo Delete (Ctrl+Z)", Message::UndoDelete)),
                     )
                 )
                 .spacing(5.0)


### PR DESCRIPTION
Implement custom delete dialogue and undo functionality

-  Deleting a song or static now opens a model asking for confirmation
-  Add support for skipping the confirmation dialogue by holding Shift
- Clicking outside the modal Cancels the delete
-  Track the deletion history of statics and songs in  DataProvider
-  Add an "Undo Delete" button and support for the Ctrl+Z shortcut

closes #182
